### PR TITLE
Add flag-evaluation spec, Makefile, initial spec structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+IS_PYTHON_INSTALLED = $(shell which python >> /dev/null 2>&1; echo $$?)
+
+parse: clean _check_python
+	@python ./tools/specification_parser/specification_parser.py
+
+clean:
+	@find ./specification -name '*.json' -delete
+
+_check_python:
+	@if [ $(IS_PYTHON_INSTALLED) -eq 1 ]; \
+		then echo "" \
+		&& echo "ERROR: python must be available on PATH." \
+		&& echo "" \
+		&& exit 1; \
+		fi;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenFeature specification (draft)
+# OpenFeature Specification (Draft)
 
 [![Roadmap](https://img.shields.io/static/v1?label=Roadmap&message=public&color=green)](https://github.com/orgs/open-feature/projects/1)
 [![Contributing](https://img.shields.io/static/v1?label=Contributing&message=guide&color=blue)](https://github.com/open-feature/.github/blob/main/CONTRIBUTING.md)
@@ -13,7 +13,7 @@ It also contains research that was considered while defining the spec.
 > Also see the ongoing research on SDK/APIs [here](./research/existing-landscape.md)
 > See the [glossary](./glossary.md) for definitions of key terminology.
 
-## Design principles
+## Design Principles
 
 - Compatibility with existing open source and commercial feature flag offerings
 - Simple, understandable API
@@ -21,7 +21,7 @@ It also contains research that was considered while defining the spec.
 - First class Kubernetes support
 - Native support for OpenTelemetry
 
-### SDKs and client libraries
+### SDKs and Client Libraries
 
 The project aims to provide a unified API and SDK for feature flag management in
 various technology stacks. The flag evaluation logic will **not** be handled in
@@ -32,6 +32,25 @@ external evaluation engine in a vendor agnostic way.
 
 The OpenFeature project will include client libraries for common technology stacks including, but not limited to:
 
-* Golang
-* Java
-* JavaScript/TypeScript
+- Golang
+- Java
+- JavaScript/TypeScript (Node.js)
+
+### Tooling
+
+This specification complies with [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) and seeks to conform to the [W3C QA Framework Guildlines](https://www.w3.org/TR/qaframe-spec/).
+
+In accordance with this, some basic tooling (donated graciously by [Diego Hurtado](https://github.com/ocelotl)) has been employed to parse the specification and output a JSON structure of concise requirements, highlighting the particular `RFC 2119` verb in question.
+
+To parse the specification, simply type `make`. Please review the generated JSON files, which will appear as siblings to any of the markdown files in the `/specification` folder.
+
+### Style Guide
+
+- Use code blocks for examples.
+  - Code blocks should be pseudocode, not any particular language, but should be vaguely "Java-esque".
+- Use conditional requirements for requirements that only apply in particular situations, such as particular languages or runtimes.
+- Use "sentence case" enclosed in ticks (\`) when identifying entities outside of code blocks (ie: `evaluation details` instead of `EvaluationDetails`).
+- Do not place line breaks into sentences, keep sentences to a single line for easier review.
+- String literals appearing outside of code blocks should be enclosed in both ticks (\`) and double-quotes (") (ie: `"PARSE_ERROR"`).
+- Use "Title Case" for all titles.
+- Use the imperative mood and passive voice.

--- a/specification/README.md
+++ b/specification/README.md
@@ -1,0 +1,34 @@
+OpenFeature Specification
+
+## Contents
+
+- [Glossary](./glossary.md)
+- [Types](./types.md)
+- [Design Principles](design-principles.md)
+- [Evaluation API](./flag-evaluation/flag-evaluation.md)
+- [Hooks](./flag-evaluation/hooks.md)
+- [Providers](./provider/providers.md)
+
+## Conformance
+
+### Normative Sections
+
+The following parts of this document are normative:
+
+- Statements under markdown H5 headings, appearing in markdown block quotes, and containing an uppercase keyword from RFC 2119.
+- This conformance clause.
+
+### Conformance Requirements and Test Assertions
+
+Each [normative section](#normative-sections) defines a single requirement. By enumerating these normative sections, a list of test assertions can be derived.
+
+### Compliance
+
+An implementation is not compliant if it fails to satisfy one or more of the "MUST", "MUST NOT", "REQUIRED", "SHALL", or "SHALL NOT" requirements defined in the [normative sections](#normative-sections) of the specification. Conversely, an implementation of the specification is compliant if it satisfies all the "MUST", "MUST NOT", "REQUIRED", "SHALL", and "SHALL NOT" requirements defined in the [normative sections](#normative-sections) of the specification.
+
+## Document Statuses
+
+| Status               | Explanation                   |
+| -------------------- | ----------------------------- |
+| No Explicit "Status" | Equivalent to Experimental.   |
+| Experimental         | Breaking changes are allowed. |

--- a/specification/design-principles.md
+++ b/specification/design-principles.md
@@ -1,0 +1,5 @@
+# Design Principles
+
+## Overview
+
+// TODO: this is a stub.

--- a/specification/evaluation-context/evaluation-context.md
+++ b/specification/evaluation-context/evaluation-context.md
@@ -1,0 +1,5 @@
+# Evaluation Context
+
+## Overview
+
+// TODO: this is a stub.

--- a/specification/flag-evaluation/flag-evaluation.json
+++ b/specification/flag-evaluation/flag-evaluation.json
@@ -1,0 +1,146 @@
+[
+    {
+        "id": "1.1",
+        "clean id": "1_1",
+        "content": "The `API`, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the `API` are present at runtime.",
+        "RFC 2119 keyword": "SHOULD"
+    },
+    {
+        "id": "1.2",
+        "clean id": "1_2",
+        "content": "The `API` MUST provide a function to set the global `provider` singleton, which accepts an API-conformant `provider` implementation.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "1.3",
+        "clean id": "1_3",
+        "content": "The `API` MUST provide a function to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "1.4",
+        "clean id": "1_4",
+        "content": "The API MUST provide a function for retrieving the `provider` implementation.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "1.5",
+        "clean id": "1_5",
+        "content": "The `API` MUST provide a function for creating a `client` which accepts the following options: - name (optional): A logical string identifier for the client.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "1.6",
+        "clean id": "1_6",
+        "content": "The client MUST provide a method to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "1.7",
+        "clean id": "1_7",
+        "content": "The `client` MUST provide methods for flag evaluation, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns the flag value.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "1.9",
+        "clean id": "1_9",
+        "content": "The `client` MUST provide methods for detailed flag value evaluation with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns an `evaluation details` structure.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "1.10",
+        "clean id": "1_10",
+        "content": "The `evaluation details` structure's `value` field MUST contain the evaluated flag value.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "1.12",
+        "clean id": "1_12",
+        "content": "The `evaluation details` structure's `flag key` field MUST contain the `flag key` argument passed to the detailed flag evaluation method.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "1.13",
+        "clean id": "1_13",
+        "content": "The `evaluation details` structure's `variant` field SHOULD contain a identifier logically corresponding to the return flag value.",
+        "RFC 2119 keyword": "SHOULD"
+    },
+    {
+        "id": "1.14",
+        "clean id": "1_14",
+        "content": "The `evaluation details` structure's `reason` field SHOULD indicate the semantic reason for the returned flag value. Possible values vary by provider, but may include `\"TARGETING_MATCH\"`, `\"SPLIT\"`, `\"DISABLED\"`, `\"DEFAULT\"`, `\"UNKNOWN\"` and `\"ERROR\"`.",
+        "RFC 2119 keyword": "SHOULD"
+    },
+    {
+        "id": "1.15",
+        "clean id": "1_15",
+        "content": "In cases of normal execution, the `evaluation details` structure's `error code` field MUST not be set, or otherwise must contain a null or falsy value.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "1.16",
+        "clean id": "1_16",
+        "content": "In cases of abnormal execution, the `evaluation details` structure's `error code` field SHOULD identify an error occurred during flag evaluation, with possible values `\"PROVIDER_NOT_READY\"`, `\"FLAG_NOT_FOUND\"`, `\"PARSE_ERROR\"`, `\"TYPE_MISMATCH\"`, or `\"GENERAL\"`.",
+        "RFC 2119 keyword": "SHOULD"
+    },
+    {
+        "id": "1.17",
+        "clean id": "1_17",
+        "content": "In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field in the `evaluation details` SHOULD indicate an error.",
+        "RFC 2119 keyword": "SHOULD"
+    },
+    {
+        "id": "1.18",
+        "clean id": "1_18",
+        "content": "The `evaluation options` structure's `hooks` field denotes a collection of hooks to be executed for the respective flag evaluation.",
+        "RFC 2119 keyword": null
+    },
+    {
+        "id": "1.19",
+        "clean id": "1_19",
+        "content": "No methods, functions, or operations on the client should ever throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup.",
+        "RFC 2119 keyword": null
+    },
+    {
+        "id": "1.20",
+        "clean id": "1_20",
+        "content": "In the case of abnormal execution, the client SHOULD log an informative error message.",
+        "RFC 2119 keyword": "SHOULD"
+    },
+    {
+        "id": "1.21",
+        "clean id": "1_21",
+        "content": "The `client` SHOULD provide asynchronous or non-blocking mechanisms for flag evaluation.",
+        "RFC 2119 keyword": "SHOULD"
+    },
+    {
+        "id": "Condition 1.8",
+        "content": "The language type system differentiates between strings, numbers, booleans and structures.",
+        "children": [
+            {
+                "id": "1.8.1",
+                "clean id": "1_8_1",
+                "content": "The `client` MUST provide methods for typed flag evaluation, including boolean, numeric, string, and structure.```// example boolean flag evaluationboolean myBool =  client.getBooleanValue('bool-flag', false);// example overloaded string flag evaluation with optional paramsstring myString = client.getStringValue('string-flag', 'N/A', evaluationContext, options);// example number flag evaluationnumber myNumber = client.getNumberValue('number-flag', 75);// example overloaded structure flag evaluation with optional paramsMyStruct myStruct = client.getObjectValue<MyStruct>('structured-flag', { text: 'N/A', percentage: 75 }, evaluationContext, options);```See [evaluation context](../evaluation-context/evaluation-context.md) for details.",
+                "RFC 2119 keyword": "MUST"
+            },
+            {
+                "id": "1.8.2",
+                "clean id": "1_8_2",
+                "content": "The `client` SHOULD guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied `default value` should be returned.",
+                "RFC 2119 keyword": "SHOULD"
+            }
+        ]
+    },
+    {
+        "id": "Condition 1.11",
+        "content": "The language supports generics (or an equivalent feature).",
+        "children": [
+            {
+                "id": "1.11.1",
+                "clean id": "1_11_1",
+                "content": "The `evaluation details` structure SHOULD accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.",
+                "RFC 2119 keyword": "SHOULD"
+            }
+        ]
+    }
+]

--- a/specification/flag-evaluation/flag-evaluation.md
+++ b/specification/flag-evaluation/flag-evaluation.md
@@ -1,0 +1,194 @@
+# Flag Evaluation API
+
+**Status**: [Experimental](../README.md#document-statuses)
+
+## Overview
+
+The `evaluation API` allows for the evaluation of feature flag values, independent of any flag control plane or vendor. In the absence of a [provider](../provider/providers.md) the `evaluation API` uses the "No-op provider", which simply returns the supplied default flag value.
+
+#### API Initialization and Configuration
+
+##### Requirement 1.1
+
+> The `API`, and any state it maintains **SHOULD** exist as a global singleton, even in cases wherein multiple versions of the `API` are present at runtime.
+
+It's important that multiple instances of the `API` not be active, so that state stored therein, such as the registered `provider`, static global `evaluation context`, and globally configured `hooks` allow the `API` to behave predictably. This can be difficult in some runtimes or languages, but implementors should make their best effort to ensure that only a single instance of the `API` is used.
+
+##### Requirement 1.2
+
+> The `API` **MUST** provide a function to set the global `provider` singleton, which accepts an API-conformant `provider` implementation.
+
+```
+// example provider mutator
+OpenFeature.setProvider(new MyProvider());
+```
+
+See [provider](../provider//providers.md) for details.
+
+##### Requirement 1.3
+
+> The `API` **MUST** provide a function to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.
+
+```
+// example hook attachment
+OpenFeature.addHooks([new MyHook()]);
+```
+
+See [hooks](./hooks.md) for details.
+
+##### Requirement 1.4
+
+> The API **MUST** provide a function for retrieving the `provider` implementation.
+
+```
+// example provider accessor
+OpenFeature.getProvider();
+```
+
+See [provider](../provider/provider.md) for details.
+
+##### Requirement 1.5
+
+> The `API` **MUST** provide a function for creating a `client` which accepts the following options:
+>
+> - name (optional): A logical string identifier for the client.
+
+```
+// example client creation and retrieval
+OpenFeature.getClient({
+  name: 'my-openfeature-client'
+});
+```
+
+The name is a logical identifier for the client.
+
+#### Client Usage
+
+##### Requirement 1.6
+
+> The client **MUST** provide a method to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.
+
+```
+// example hook attachment
+client.addHooks([new MyHook()]);
+```
+
+See [hooks](./hooks.md) for details.
+
+#### Flag Evaluation
+
+##### Requirement 1.7
+
+> The `client` **MUST** provide methods for flag evaluation, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns the flag value.
+
+```
+// example flag evaluation
+var myValue = client.getValue('my-flag', false);
+```
+
+##### Condition 1.8
+
+> The language type system differentiates between strings, numbers, booleans and structures.
+>
+> ##### Conditional Requirement 1.8.1
+>
+> > The `client` **MUST** provide methods for typed flag evaluation, including boolean, numeric, string, and structure.
+>
+> > ```
+> > // example boolean flag evaluation
+> > boolean myBool =  client.getBooleanValue('bool-flag', false);
+> >
+> > // example overloaded string flag evaluation with optional params
+> > string myString = client.getStringValue('string-flag', 'N/A', evaluationContext, options);
+> >
+> > // example number flag evaluation
+> > number myNumber = client.getNumberValue('number-flag', 75);
+> >
+> > // example overloaded structure flag evaluation with optional params
+> > MyStruct myStruct = client.getObjectValue<MyStruct>('structured-flag', { text: 'N/A', percentage: 75 }, evaluationContext, options);
+> > ```
+>
+> > See [evaluation context](../evaluation-context/evaluation-context.md) for details.
+>
+> ##### Conditional Requirement 1.8.2
+>
+> > The `client` **SHOULD** guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied `default value` should be returned.
+
+##### Requirement 1.9
+
+> The `client` **MUST** provide methods for detailed flag value evaluation with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns an `evaluation details` structure.
+
+```
+// example detailed boolean flag evaluation
+FlagEvaluationDetails<boolean> myBoolDetails = client.getBooleanDetails('bool-flag', false);
+
+// example detailed string flag evaluation
+FlagEvaluationDetails<string> myStringDetails = client.getStringDetails('string-flag', 'N/A', evaluationContext, options);
+
+// example detailed number flag evaluation
+FlagEvaluationDetails<number> myNumberDetails = client.getNumberDetails('number-flag', 75);
+
+// example detailed structure flag evaluation
+FlagEvaluationDetails<MyStruct> myStructDetails = client.getObjectDetails<MyStruct>('structured-flag', { text: 'N/A', percentage: 75 }, evaluationContext, options);
+
+```
+
+##### Requirement 1.10
+
+> The `evaluation details` structure's `value` field **MUST** contain the evaluated flag value.
+
+##### Condition 1.11
+
+> The language supports generics (or an equivalent feature).
+>
+> ##### Conditional Requirement 1.11.1
+>
+> > The `evaluation details` structure **SHOULD** accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.
+
+##### Requirement 1.12
+
+> The `evaluation details` structure's `flag key` field **MUST** contain the `flag key` argument passed to the detailed flag evaluation method.
+
+##### Requirement 1.13
+
+> The `evaluation details` structure's `variant` field **SHOULD** contain a identifier logically corresponding to the return flag value.
+
+For example, the flag value might be `3.14159265359`, and the variant field's value might be `"pi"`.
+
+##### Requirement 1.14
+
+> The `evaluation details` structure's `reason` field **SHOULD** indicate the semantic reason for the returned flag value. Possible values vary by provider, but may include `"TARGETING_MATCH"`, `"SPLIT"`, `"DISABLED"`, `"DEFAULT"`, `"UNKNOWN"` and `"ERROR"`.
+
+##### Requirement 1.15
+
+> In cases of normal execution, the `evaluation details` structure's `error code` field **MUST** not be set, or otherwise must contain a null or falsy value.
+
+##### Requirement 1.16
+
+> In cases of abnormal execution, the `evaluation details` structure's `error code` field **SHOULD** identify an error occurred during flag evaluation, with possible values `"PROVIDER_NOT_READY"`, `"FLAG_NOT_FOUND"`, `"PARSE_ERROR"`, `"TYPE_MISMATCH"`, or `"GENERAL"`.
+
+##### Requirement 1.17
+
+> In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field in the `evaluation details` **SHOULD** indicate an error.
+
+##### Requirement 1.18
+
+> The `evaluation options` structure's `hooks` field denotes a collection of hooks to be executed for the respective flag evaluation.
+
+See [hooks](./hooks.md) for details.
+
+##### Requirement 1.19
+
+> No methods, functions, or operations on the client should ever throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup.
+
+##### Requirement 1.20
+
+> In the case of abnormal execution, the client **SHOULD** log an informative error message.
+
+Implementations may define a standard logging interface that can be supplied as an optional argument to the client creation function, which may wrap standard logging functionality of the implementation language.
+
+##### Requirement 1.21
+
+> The `client` **SHOULD** provide asynchronous or non-blocking mechanisms for flag evaluation.
+
+It's recommended to provide non-blocking mechanisms for flag evaluation, particularly in languages or environments wherein there's a single thread of execution.

--- a/specification/flag-evaluation/hooks.md
+++ b/specification/flag-evaluation/hooks.md
@@ -1,0 +1,5 @@
+# Hooks
+
+## Overview
+
+// TODO: this is a stub.

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -58,6 +58,10 @@ The interfaces and abstractions used by authors (Application, Integration, Provi
 Provider & Integration authors adhere to the API to add support for their feature flag implementation or integration.
 Application authors use it via the Feature Flag SDK.
 
+### Evaluation API
+
+The subset of the [Feature Flag API](#feature-flag-api) that the Application Author uses to evaluate flags.
+
 ### Provider
 
 An SDK-compliant feature flag implementation which adheres to the Feature Flag API. Implementations may include Saas feature flag vendors, custom "in-house" feature flag infrastructure, or open-source implementations.
@@ -86,7 +90,7 @@ Flags represent a single pivot point of logic. Flags have a type, like `string`,
 
 ### Variant
 
-A variant is a space-constrained identifier for values. This allows us to reference these values without having to include all of the data (which may be quite large). We may use some hash of the values themselves or a string name. So for the `header-order` flag, we may have variants like `reverse`, `wonky` or `standard`.
+A variant is a semantic identifier for a value. This allows for referral to particular values without necessarily including the value itself, which may be quite prohibitively large or otherwise unsuitable in some cases.
 
 ### Values
 

--- a/specification/provider/providers.md
+++ b/specification/provider/providers.md
@@ -1,0 +1,5 @@
+# Providers
+
+## Overview
+
+// TODO: this is a stub.

--- a/specification/types.md
+++ b/specification/types.md
@@ -1,0 +1,37 @@
+# Types and Data Structures
+
+## Overview
+
+This document outlines some of the common types and data structures defined by OpenFeature and referenced elsewhere in this specification.
+
+### boolean
+
+A logical true or false, as represented idiomatically in the implementation languages.
+
+### string
+
+A UTF-8 encoded string.
+
+### number
+
+A numeric value of unspecified type or size. Implementation languages may further differentiate between integers, floating point numbers, and other specific numeric types and provide functionality as idioms dictate.
+
+### structure
+
+Structured data, presented however is idiomatic in the implementation language, such as JSON or YAML.
+
+### evaluation details
+
+A structure containing the following fields:
+
+- flag key (string, required)
+- value (boolean | string | number | structure, required)
+- error code (string, optional)
+- reason (string, optional)
+- variant (string, optional)
+
+### evaluation options
+
+A structure containing the following fields:
+
+- hooks (one or more [hooks](./flag-evaluation/hooks.md), optional)

--- a/tools/specification_parser/specification_parser.py
+++ b/tools/specification_parser/specification_parser.py
@@ -1,0 +1,205 @@
+from re import (
+    finditer, findall, compile as compile_, DOTALL, sub, match, search
+)
+from json import dumps
+from os.path import curdir, abspath, join, splitext
+from os import walk
+
+rfc_2119_keywords_regexes = [
+    r"MUST",
+    r"REQUIRED",
+    r"SHALL",
+    r"MUST NOT",
+    r"SHALL NOT",
+    r"SHOULD",
+    r"RECOMMENDED",
+    r"SHOULD NOT",
+    r"NOT RECOMMENDED",
+    r"MAY",
+    r"OPTIONAL",
+]
+
+
+def find_markdown_file_paths(root):
+    markdown_file_paths = []
+
+    for root_path, _, file_paths, in walk(root):
+        for file_path in file_paths:
+
+            absolute_file_path = join(root_path, file_path)
+
+            _, file_extension = splitext(absolute_file_path)
+
+            if file_extension == ".md":
+                markdown_file_paths.append(absolute_file_path)
+
+    return markdown_file_paths
+
+
+def clean_content(content):
+
+    for rfc_2119_keyword_regex in rfc_2119_keywords_regexes:
+
+        content = sub(
+            f"\\*\\*{rfc_2119_keyword_regex}\\*\\*",
+            rfc_2119_keyword_regex,
+            content
+        )
+
+    return sub(r"\n>", "", content)
+
+
+def find_rfc_2119_keyword(content):
+
+    for rfc_2119_keyword_regex in rfc_2119_keywords_regexes:
+
+        if search(
+            f"\\*\\*{rfc_2119_keyword_regex}\\*\\*", content
+        ) is not None:
+            return rfc_2119_keyword_regex
+
+
+def parse_requirements(markdown_file_path):
+
+    requirements = []
+
+    with open(markdown_file_path, "r") as markdown_file:
+
+        for requirement in [
+            requirement_match.groupdict() for requirement_match in (
+                finditer(
+                    r"##### Requirement (?P<id>(.*?)+)\n\n"
+                    r"> (?P<content>(.*?))\n\n",
+                    markdown_file.read() + "\n\n",
+                    DOTALL
+                )
+            )
+        ]:
+
+            content = requirement["content"]
+
+            requirements.append(
+                {
+                    "id": requirement["id"],
+                    "clean id": sub(r"[^\w]", "_", requirement["id"].lower()),
+                    "content": clean_content(content),
+                    "RFC 2119 keyword": find_rfc_2119_keyword(content)
+                }
+            )
+
+    return requirements
+
+
+regex = compile_(
+    r"(?P<level>(> ?)*)(?P<pounds>##### )?(?P<content>.*)"
+)
+
+
+def parse_conditions(markdown_file_path):
+
+    conditions = []
+
+    with open(markdown_file_path, "r") as markdown_file:
+
+        for condition in findall(
+            r"##### Condition [0-9.]+\n\n.*?\n\n",
+            markdown_file.read() + "\n\n",
+            DOTALL
+        ):
+
+            stack = []
+
+            text = ""
+
+            for line in condition.split("\n"):
+                regex_dict = regex.match(line).groupdict()
+
+                level = len(regex_dict["level"].split())
+                pounds = regex_dict["pounds"]
+                content = regex_dict["content"]
+
+                if not level and not content:
+                    continue
+
+                if not pounds:
+                    text = "".join([text, content])
+                    continue
+
+                if match(
+                    r"(> ?)*##### Condition [0-9.]+", line
+                ) is not None:
+
+                    node = {
+                        "id": content,
+                        "content": "",
+                        "children": []
+                    }
+                else:
+
+                    content = sub(r"Conditional Requirement ", "", content)
+
+                    node = {
+                        "id": content,
+                        "clean id": sub(r"[^\w]", "_", content.lower()),
+                        "content": "",
+                        "RFC 2119 keyword": None
+                    }
+
+                if not stack:
+                    stack.append(node)
+                    continue
+
+                stack[-1]["content"] = clean_content(text)
+
+                if level == len(stack) - 1:
+
+                    stack[-1]["RFC 2119 keyword"] = find_rfc_2119_keyword(
+                        text
+                    )
+                    stack.pop()
+
+                elif level < len(stack) - 1:
+                    stack[-1]["RFC 2119 keyword"] = find_rfc_2119_keyword(
+                        text
+                    )
+                    for _ in range(len(stack) - level):
+                        stack.pop()
+
+                text = ""
+                stack[-1]["children"].append(node)
+                stack.append(node)
+
+            stack[-1]["content"] = clean_content(text)
+            stack[-1]["RFC 2119 keyword"] = find_rfc_2119_keyword(
+                text
+            )
+
+            conditions.append(stack[0])
+
+    return conditions
+
+
+def write_json_specifications(requirements, conditions):
+    for md_absolute_file_path, requirement_sections in requirements.items():
+
+        with open(
+            "".join([splitext(md_absolute_file_path)[0], ".json"]), "w"
+        ) as json_file:
+            json_file.write(dumps(requirement_sections, indent=4))
+
+
+if __name__ == "__main__":
+
+    for markdown_file_path in find_markdown_file_paths(
+        join(abspath(curdir))
+    ):
+
+        result = []
+        result.extend(parse_requirements(markdown_file_path))
+        result.extend(parse_conditions(markdown_file_path))
+
+        if result:
+            with open(
+                "".join([splitext(markdown_file_path)[0], ".json"]), "w"
+            ) as json_file:
+                json_file.write(dumps(result, indent=4))

--- a/tools/specification_parser/specification_parser_test.py
+++ b/tools/specification_parser/specification_parser_test.py
@@ -1,0 +1,139 @@
+from unittest import TestCase
+from os.path import abspath, curdir, join
+
+from specification_parser import (
+    find_markdown_file_paths,
+    parse_requirements,
+    parse_conditions
+)
+
+
+class TestSpecificationParser(TestCase):
+    """
+    Tests for the specification parser
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.current_directory_path = abspath(curdir)
+        cls.test_specification_md_path = join(
+            cls.current_directory_path, "test_specification.md"
+        )
+
+    def test_find_markdown_file_paths(self):
+        self.assertIn(
+            self.test_specification_md_path,
+            find_markdown_file_paths(self.current_directory_path)
+        )
+
+    def test_parse_requirements(self):
+        self.maxDiff = None
+        self.assertEqual(
+            [
+                {
+                    "id": "Some requirement",
+                    "clean id": "some_requirement",
+                    "content": "This MUST be done.",
+                    "RFC 2119 keyword": "MUST"
+                },
+                {
+                    "id": "Some other requirement",
+                    "clean id": "some_other_requirement",
+                    "content": "This MUST NOT be done.",
+                    "RFC 2119 keyword": "MUST NOT"
+                },
+                {
+                    "id": "Another requirement-name",
+                    "clean id": "another_requirement_name",
+                    "content": "This SHOULD be done in a certain way.",
+                    "RFC 2119 keyword": "SHOULD"
+                },
+                {
+                    "id": "This is the name of-the-requirement",
+                    "clean id": "this_is_the_name_of_the_requirement",
+                    "content": "This MUST NOT be done.",
+                    "RFC 2119 keyword": "MUST NOT"
+                },
+            ],
+            parse_requirements(self.test_specification_md_path)
+        )
+
+    def test_parse_conditions(self):
+        self.maxDiff = None
+        self.assertEqual(
+            [
+                {
+                    "id": "Condition 1",
+                    "content": "This is a condition.",
+                    "children": [
+                        {
+                            "id": "Condition 1.1",
+                            "content": "This is a condition.",
+                            "children": [
+                                {
+                                    "id": "Condition 1.1.1",
+                                    "content": "This is a condition.",
+                                    "children": [
+                                        {
+                                            "id": "Conditional requirement name",
+                                            "clean id": "conditional_requirement_name",
+                                            "content": "This MAY be done.",
+                                            "RFC 2119 keyword": "MAY"
+                                        },
+                                        {
+                                            "id": "Other name",
+                                            "clean id": "other_name",
+                                            "content": "This SHOULD NOT be done.",
+                                            "RFC 2119 keyword": "SHOULD NOT"
+                                        },
+                                        {
+                                            "id": "Another name here",
+                                            "clean id": "another_name_here",
+                                            "content": "This MAY be done.",
+                                            "RFC 2119 keyword": "MAY"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "Condition 1.2",
+                            "content": "This is a condition.",
+                            "children": [
+                                {
+                                    "id": "And another-name",
+                                    "clean id": "and_another_name",
+                                    "content": "This MUST be done.",
+                                    "RFC 2119 keyword": "MUST"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "Condition 2",
+                    "content": "This is a condition.",
+                    "children": [
+                        {
+                            "id": "Condition 2.1",
+                            "content": "This is a condition.",
+                            "children": [
+                                {
+                                    "id": "Condition 2.2",
+                                    "content": "This is a condition.",
+                                    "children": [
+                                        {
+                                            "id": "The name here",
+                                            "clean id": "the_name_here",
+                                            "content": "This MAY be done.",
+                                            "RFC 2119 keyword": "MAY"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            parse_conditions(self.test_specification_md_path)
+        )

--- a/tools/specification_parser/test_specification.json
+++ b/tools/specification_parser/test_specification.json
@@ -1,0 +1,98 @@
+[
+    {
+        "id": "Some requirement",
+        "clean id": "some_requirement",
+        "content": "This MUST be done.",
+        "RFC 2119 keyword": "MUST"
+    },
+    {
+        "id": "Some other requirement",
+        "clean id": "some_other_requirement",
+        "content": "This MUST NOT be done.",
+        "RFC 2119 keyword": "MUST NOT"
+    },
+    {
+        "id": "Another requirement-name",
+        "clean id": "another_requirement_name",
+        "content": "This SHOULD be done in a certain way.",
+        "RFC 2119 keyword": "SHOULD"
+    },
+    {
+        "id": "This is the name of-the-requirement",
+        "clean id": "this_is_the_name_of_the_requirement",
+        "content": "This MUST NOT be done.",
+        "RFC 2119 keyword": "MUST NOT"
+    },
+    {
+        "id": "Condition 1",
+        "content": "This is a condition.",
+        "children": [
+            {
+                "id": "Condition 1.1",
+                "content": "This is a condition.",
+                "children": [
+                    {
+                        "id": "Condition 1.1.1",
+                        "content": "This is a condition.",
+                        "children": [
+                            {
+                                "id": "Conditional requirement name",
+                                "clean id": "conditional_requirement_name",
+                                "content": "This MAY be done.",
+                                "RFC 2119 keyword": "MAY"
+                            },
+                            {
+                                "id": "Other name",
+                                "clean id": "other_name",
+                                "content": "This SHOULD NOT be done.",
+                                "RFC 2119 keyword": "SHOULD NOT"
+                            },
+                            {
+                                "id": "Another name here",
+                                "clean id": "another_name_here",
+                                "content": "This MAY be done.",
+                                "RFC 2119 keyword": "MAY"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "Condition 1.2",
+                "content": "This is a condition.",
+                "children": [
+                    {
+                        "id": "And another-name",
+                        "clean id": "and_another_name",
+                        "content": "This MUST be done.",
+                        "RFC 2119 keyword": "MUST"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "id": "Condition 2",
+        "content": "This is a condition.",
+        "children": [
+            {
+                "id": "Condition 2.1",
+                "content": "This is a condition.",
+                "children": [
+                    {
+                        "id": "Condition 2.2",
+                        "content": "This is a condition.",
+                        "children": [
+                            {
+                                "id": "The name here",
+                                "clean id": "the_name_here",
+                                "content": "This MAY be done.",
+                                "RFC 2119 keyword": "MAY"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/tools/specification_parser/test_specification.md
+++ b/tools/specification_parser/test_specification.md
@@ -1,0 +1,74 @@
+# Test Specification
+
+## Title
+
+Some content.
+
+##### Requirement Some requirement
+
+> This **MUST** be done.
+
+##### Requirement Some other requirement
+
+> This **MUST NOT** be done.
+
+##### Requirement Another requirement-name
+
+> This **SHOULD** be done
+> in a certain way.
+
+##### Condition 1
+
+> This is a condition.
+>
+> ##### Condition 1.1
+>
+> > This is a condition.
+> >
+> > ##### Condition 1.1.1
+> >
+> > > This is a condition.
+> > >
+> > > ##### Conditional Requirement Conditional requirement name
+> > >
+> > > > This **MAY** be done.
+> > >
+> > > ##### Conditional Requirement Other name
+> > >
+> > > > This **SHOULD NOT** be done.
+> > >
+> > > ##### Conditional Requirement Another name here
+> > >
+> > > > This **MAY** be done.
+>
+> ##### Condition 1.2
+>
+> > This is a condition.
+> >
+> > ##### Conditional Requirement And another-name
+> >
+> > > This **MUST** be done.
+
+Some content.
+
+##### Requirement This is the name of-the-requirement
+
+> This **MUST NOT** be done.
+
+##### Condition 2
+
+> This is a condition.
+>
+> ##### Condition 2.1
+>
+> > This is a condition.
+> >
+> > ##### Condition 2.2
+> >
+> > > This is a condition.
+> > >
+> > > ##### Conditional Requirement The name here
+> > >
+> > > > This **MAY** be done.
+
+Some content.


### PR DESCRIPTION
First pass at a partial spec, based on cumulative findings from our [research repo](https://github.com/open-feature/sdk-research). Only the `Evaluation API` is proposed (`specification/flag-evaluation/flag-evaluation.md`, also note the associated assertion JSON file: `specification/flag-evaluation/flag-evaluation.json`). The best way to view the actual spec is probably to view the branch directly, since it's mostly markdown: https://github.com/open-feature/spec/tree/spec/flag-evaluation-api/specification

One of the goals was to design the structure of the spec, so I've included stubs for some of the other parts.

Please also checkout the `specification/README.md`, which contains an overview, conformance clause, and document statuses. 

For ease of generating the JSON assertion files, I've also added a very simple Makefile. If you're interested in looking at spec only, please make use of the Github's file-type filter: 
![image](https://user-images.githubusercontent.com/25272906/164499328-5401eccd-1056-4e21-b7f1-7d29305bcded.png)


UPDATE: 

I believe I've addressed all the concerns. I've also opened: https://github.com/open-feature/spec/issues/36 in response to comments about CI and various helpful automation suggestions. Please remember, everything in the spec at the moment is still `status: experimental`, so don't think that anything here is final!