### PR TITLE
Adds a linter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ parse: clean _check_python
 clean:
 	@find ./specification -name '*.json' -delete
 
+lint:
+	@python ./tools/specification_parser/lint_json_output.py specification/
+
 _check_python:
 	@if [ $(IS_PYTHON_INSTALLED) -eq 1 ]; \
 		then echo "" \
@@ -14,7 +17,6 @@ _check_python:
 		&& echo "" \
 		&& exit 1; \
 		fi;
-
 .PHONY: markdown-toc
 markdown-toc:
 	@if ! npm ls markdown-toc; then npm install; fi

--- a/tools/specification_parser/lint_json_output.py
+++ b/tools/specification_parser/lint_json_output.py
@@ -1,0 +1,40 @@
+from os.path import curdir, abspath, join, splitext
+from os import walk
+import json
+import sys
+
+
+def main(dir):
+    jsons = []
+    for root_path, _, file_paths, in walk(dir):
+        for file_path in file_paths:
+            absolute_file_path = join(root_path, file_path)
+
+            _, file_extension = splitext(absolute_file_path)
+
+            if file_extension == ".json":
+                jsons.append(absolute_file_path)
+
+    errors = 0
+    for j in jsons:
+        with open(j) as jfile:
+            spec = json.load(jfile)
+            entries = spec;
+            for entry in spec:
+                for child in entry.get('children', []):
+                    entries.append(child)
+            try:
+                for entry in entries:
+                    if entry['RFC 2119 keyword'] is None:
+                        print(f"{j}: Rule {entry['id']} is missing a RFC 2119 keyword", file=sys.stderr)
+                        errors += 1
+                    pass
+            except:
+                print(f"Non json-spec formatted file found: {j}", file=sys.stderr)
+    sys.exit(errors)
+
+def has_errors(entry):
+    pass
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/tools/specification_parser/lint_json_output.py
+++ b/tools/specification_parser/lint_json_output.py
@@ -25,11 +25,12 @@ def main(dir):
                     entries.append(child)
             try:
                 for entry in entries:
-                    if entry['RFC 2119 keyword'] is None:
+                    if entry.get('RFC 2119 keyword') is None and \
+                       'condition' not in entry['id'].lower():
                         print(f"{j}: Rule {entry['id']} is missing a RFC 2119 keyword", file=sys.stderr)
                         errors += 1
                     pass
-            except:
+            except Exception as k:
                 print(f"Non json-spec formatted file found: {j}", file=sys.stderr)
     sys.exit(errors)
 


### PR DESCRIPTION
Example output:

```
❯ make lint
Non json-spec formatted file found: specification/flag-evaluation/something.json
specification/flag-evaluation/flag-evaluation.json: Rule 1.18 is missing a RFC 2119 keyword
specification/flag-evaluation/flag-evaluation.json: Rule 1.19 is missing a RFC 2119 keyword
Non json-spec formatted file found: specification/flag-evaluation/flag-evaluation.json
make: *** [lint] Error 2
```