### PR TITLE
parser: add support for .specignore file

### DIFF
--- a/.specignore
+++ b/.specignore
@@ -1,0 +1,7 @@
+# line separated list of UNIX shell style globs of files to ignore
+
+# Ignore all README files
+**/README.md
+
+# Ignore all files in tools directory
+tools


### PR DESCRIPTION
When running the parser I was annoyed that some non-specification files had JSON files created, so I modified the parser to support a basic `.specignore` file which is just a line-separated list of UNIX style globs.

Also cleaned up some unused and duplicate imports in the parser