### PR TITLE
Add evaluation context spec

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -48,11 +48,11 @@ jobs:
       - uses: actions/setup-python@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Generate ToC
         run: make markdown-toc
-  
+
       - name: Check for file changes
         run: |
           if [[ $(git diff --name-only) ]]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ _check_python:
 		fi;
 .PHONY: markdown-toc
 markdown-toc:
-	@if ! npm ls markdown-toc; then npm install; fi
+	@if ! npm ls markdown-toc; then npm ci; fi
 	@for f in $(ALL_DOCS); do \
 		if grep -q '<!-- tocstop -->' $$f; then \
 			echo markdown-toc: processing $$f; \

--- a/specification/README.md
+++ b/specification/README.md
@@ -6,8 +6,9 @@
 - [Types](./types.md)
 - [Design Principles](design-principles.md)
 - [Evaluation API](./flag-evaluation/flag-evaluation.md)
-- [Hooks](./flag-evaluation/hooks.md)
 - [Providers](./provider/providers.md)
+- [Evaluation Context](./evaluation-context/evaluation-context.md)
+- [Hooks](./flag-evaluation/hooks.md)
 
 ## Conformance
 

--- a/specification/evaluation-context/evaluation-context.json
+++ b/specification/evaluation-context/evaluation-context.json
@@ -1,0 +1,16 @@
+[
+    {
+        "id": "Requirement 3.1",
+        "clean id": "requirement_3_1",
+        "content": "The `evaluation context` structure MUST define an optional `targeting key` field of type string, identifying the subject of the flag evaluation.",
+        "RFC 2119 keyword": "MUST",
+        "children": []
+    },
+    {
+        "id": "Requirement 3.2",
+        "clean id": "requirement_3_2",
+        "content": "The evaluation context MUST support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | datetime | structure`.",
+        "RFC 2119 keyword": "MUST",
+        "children": []
+    }
+]

--- a/specification/evaluation-context/evaluation-context.md
+++ b/specification/evaluation-context/evaluation-context.md
@@ -1,5 +1,25 @@
 # Evaluation Context
 
+**Status**: [Experimental](../README.md#document-statuses)
+
 ## Overview
 
-// TODO: this is a stub.
+The `evaluation context` provides ambient information for the purposes of flag evaluation. Contextual data may be used as the basis for targeting, including rule-based evaluation, overrides for specific subjects, or fractional flag evaluation.
+
+### Fields
+
+NOTE: Field casing is not specified, and should be chosen in accordance with language idioms.
+
+see: [types](../types.md)
+
+##### Requirement 3.1
+
+> The `evaluation context` structure **MUST** define an optional `targeting key` field of type string, identifying the subject of the flag evaluation.
+
+The targeting key uniquely identifies the subject (end-user, or client service) of a flag evaluation. Providers may require this field for fractional flag evaluation, rules, or overrides targeting specific users. Such providers may behave unpredictably if a targeting key is not specified at flag resolution.
+
+##### Requirement 3.2
+
+> The evaluation context **MUST** support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | datetime | structure`.
+
+see: [structure](../types.md#structure), [datetime](../types.md#datetime)

--- a/specification/flag-evaluation/flag-evaluation.json
+++ b/specification/flag-evaluation/flag-evaluation.json
@@ -165,8 +165,8 @@
     {
         "id": "Requirement 1.21",
         "clean id": "requirement_1_21",
-        "content": "The `client` MUST transform the `evaluation context` using the `provider's` `context transformer` function, before passing the result of the transformation to the provider's flag resolution functions.",
-        "RFC 2119 keyword": "MUST",
+        "content": "The `client` SHOULD transform the `evaluation context` using the `provider's` `context transformer` function if one is defined, before passing the result of the transformation to the provider's flag resolution functions.",
+        "RFC 2119 keyword": "SHOULD",
         "children": []
     }
 ]

--- a/specification/flag-evaluation/flag-evaluation.md
+++ b/specification/flag-evaluation/flag-evaluation.md
@@ -191,6 +191,6 @@ It's recommended to provide non-blocking mechanisms for flag evaluation, particu
 
 ##### Requirement 1.21
 
-> The `client` **MUST** transform the `evaluation context` using the `provider's` `context transformer` function, before passing the result of the transformation to the provider's flag resolution functions.
+> The `client` **SHOULD** transform the `evaluation context` using the `provider's` `context transformer` function if one is defined, before passing the result of the transformation to the provider's flag resolution functions.
 
 See [context transformation](../provider/providers.md#context-transformation) for details.

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -28,6 +28,8 @@ This document defines some terms that are used across this specification.
   * [Flag](#flag)
   * [Variant](#variant)
   * [Values](#values)
+  * [Targeting](#targeting)
+  * [Fractional Evaluation](#fractional-evaluation)
   * [Rule](#rule)
 
 <!-- tocstop -->
@@ -132,6 +134,14 @@ reverse: [5,4,3,2,1]
 wonky: [3,5,2,1,4]
 standard: [1,2,3,4,5]
 ```
+
+### Targeting
+
+The application of rules, specific user overrides, or fractional evaluations in feature flag resolution.
+
+### Fractional Evaluation
+
+Assigning flag values randomly according to a configured proportion or percentage (ie: 50/50).
 
 ### Rule
 

--- a/specification/provider/providers.md
+++ b/specification/provider/providers.md
@@ -23,7 +23,7 @@ The `provider` API defines interfaces that Provider Authors can use to abstract 
 resolveBooleanValue(flagKey, defaultValue, context, options);
 ```
 
-See: [flag resolution structure](../types.md#flag-resolution), [flag value resolution](../glossary.md#flag-value-resolution)
+see: [flag resolution structure](../types.md#flag-resolution), [flag value resolution](../glossary.md#flag-value-resolution)
 
 ##### Condition 2.3
 

--- a/specification/types.md
+++ b/specification/types.md
@@ -20,6 +20,10 @@ A numeric value of unspecified type or size. Implementation languages may furthe
 
 Structured data, presented however is idiomatic in the implementation language, such as JSON or YAML.
 
+### Datetime
+
+A language primitive for representing a date and time, including timezone information.
+
 ### Evaluation Details
 
 A structure representing the result of the [flag evaluation process](./glossary.md#evaluating-flag-values), and made available in the [detailed flag resolution functions](./flag-evaluation/flag-evaluation.md#detailed-flag-evaluation), containing the following fields:


### PR DESCRIPTION
First pass at evaluation context.

Lot's of questions here. I opted not to leverage something like the [elastic common schema](https://www.elastic.co/guide/en/ecs/current/ecs-client.html) for now, I believe it might be overkill. I used it, as well as [OIDCs standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) only as inspiration.
