### PR TITLE
Language & number consistency

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,7 +1,5 @@
 default: true
-MD013:
-  code_blocks: false
-  tables: false
+MD013: false
 MD033:
   allowed_elements:
     - summary

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,1 +1,1 @@
-proseWrap: always
+proseWrap: never

--- a/specification.json
+++ b/specification.json
@@ -159,7 +159,7 @@
         {
             "id": "Requirement 1.5.1",
             "machine_id": "requirement_1_5_1",
-            "content": "The `evaluation options` structure's `hooks` field denotes a collection of hooks that the client MUST execute for the respective flag evaluation, in addition to those already configured.",
+            "content": "The `evaluation options` structure's `hooks` field denotes an ordered collection of hooks that the client MUST execute for the respective flag evaluation, in addition to those already configured.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -351,7 +351,7 @@
         {
             "id": "Requirement 4.3.4",
             "machine_id": "requirement_4_3_4",
-            "content": "When `before` hooks have finished executing, any resulting `EvaluationContext`  MUST be merged with the invocation `EvaluationContext` with the invocation `EvaluationContext` taking precedence in the case of any conflicts.",
+            "content": "When `before` hooks have finished executing, any resulting `EvaluationContext` MUST be merged with the invocation `EvaluationContext` with the invocation `EvaluationContext` taking precedence in the case of any conflicts.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -381,7 +381,15 @@
             "machine_id": "condition_4_3_8",
             "content": "`finally` is a reserved word in the language.",
             "RFC 2119 keyword": null,
-            "children": []
+            "children": [
+                {
+                    "id": "Conditional Requirement 4.3.8.1",
+                    "machine_id": "conditional_requirement_4_3_8_1",
+                    "content": "Instead of `finally`, `finallyAfter` SHOULD be used.",
+                    "RFC 2119 keyword": "SHOULD",
+                    "children": []
+                }
+            ]
         },
         {
             "id": "Requirement 4.4.1",

--- a/specification.json
+++ b/specification.json
@@ -1,70 +1,70 @@
 {
     "rules": [
         {
-            "id": "Requirement 1.1",
-            "machine_id": "requirement_1_1",
+            "id": "Requirement 1.1.1",
+            "machine_id": "requirement_1_1_1",
             "content": "The `API`, and any state it maintains SHOULD exist as a global singleton, even in cases wherein multiple versions of the `API` are present at runtime.",
             "RFC 2119 keyword": "SHOULD",
             "children": []
         },
         {
-            "id": "Requirement 1.2",
-            "machine_id": "requirement_1_2",
+            "id": "Requirement 1.1.2",
+            "machine_id": "requirement_1_1_2",
             "content": "The `API` MUST provide a function to set the global `provider` singleton, which accepts an API-conformant `provider` implementation.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 1.3",
-            "machine_id": "requirement_1_3",
+            "id": "Requirement 1.1.3",
+            "machine_id": "requirement_1_1_3",
             "content": "The `API` MUST provide a function to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 1.4",
-            "machine_id": "requirement_1_4",
+            "id": "Requirement 1.1.4",
+            "machine_id": "requirement_1_1_4",
             "content": "The API MUST provide a function for retrieving the `provider` implementation.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 1.5",
-            "machine_id": "requirement_1_5",
+            "id": "Requirement 1.1.5",
+            "machine_id": "requirement_1_1_5",
             "content": "The `API` MUST provide a function for creating a `client` which accepts the following options:  - name (optional): A logical string identifier for the client.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 1.6",
-            "machine_id": "requirement_1_6",
+            "id": "Requirement 1.2.1",
+            "machine_id": "requirement_1_2_1",
             "content": "The client MUST provide a method to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 1.7",
-            "machine_id": "requirement_1_7",
+            "id": "Requirement 1.3.1",
+            "machine_id": "requirement_1_3_1",
             "content": "The `client` MUST provide methods for flag evaluation, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns the flag value.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Condition 1.8",
-            "machine_id": "condition_1_8",
+            "id": "Condition 1.3.2",
+            "machine_id": "condition_1_3_2",
             "content": "The language type system differentiates between strings, numbers, booleans and structures.",
             "RFC 2119 keyword": null,
             "children": [
                 {
-                    "id": "Conditional Requirement 1.8.1",
-                    "machine_id": "conditional_requirement_1_8_1",
+                    "id": "Conditional Requirement 1.3.2.1",
+                    "machine_id": "conditional_requirement_1_3_2_1",
                     "content": "The `client` MUST provide methods for typed flag evaluation, including boolean, numeric, string, and structure.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 },
                 {
-                    "id": "Conditional Requirement 1.8.2",
-                    "machine_id": "conditional_requirement_1_8_2",
+                    "id": "Conditional Requirement 1.3.3",
+                    "machine_id": "conditional_requirement_1_3_3",
                     "content": "The `client` SHOULD guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied `default value` should be returned.",
                     "RFC 2119 keyword": "SHOULD",
                     "children": []
@@ -72,28 +72,28 @@
             ]
         },
         {
-            "id": "Requirement 1.9",
-            "machine_id": "requirement_1_9",
+            "id": "Requirement 1.4.1",
+            "machine_id": "requirement_1_4_1",
             "content": "The `client` MUST provide methods for detailed flag value evaluation with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns an `evaluation details` structure.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 1.10",
-            "machine_id": "requirement_1_10",
+            "id": "Requirement 1.4.2",
+            "machine_id": "requirement_1_4_2",
             "content": "The `evaluation details` structure's `value` field MUST contain the evaluated flag value.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Condition 1.11",
-            "machine_id": "condition_1_11",
+            "id": "Condition 1.4.3",
+            "machine_id": "condition_1_4_3",
             "content": "The language supports generics (or an equivalent feature).",
             "RFC 2119 keyword": null,
             "children": [
                 {
-                    "id": "Conditional Requirement 1.11.1",
-                    "machine_id": "conditional_requirement_1_11_1",
+                    "id": "Conditional Requirement 1.4.3.1",
+                    "machine_id": "conditional_requirement_1_4_3_1",
                     "content": "The `evaluation details` structure SHOULD accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.",
                     "RFC 2119 keyword": "SHOULD",
                     "children": []
@@ -101,71 +101,71 @@
             ]
         },
         {
-            "id": "Requirement 1.12",
-            "machine_id": "requirement_1_12",
+            "id": "Requirement 1.4.4",
+            "machine_id": "requirement_1_4_4",
             "content": "The `evaluation details` structure's `flag key` field MUST contain the `flag key` argument passed to the detailed flag evaluation method.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 1.13",
-            "machine_id": "requirement_1_13",
+            "id": "Requirement 1.4.5",
+            "machine_id": "requirement_1_4_5",
             "content": "In cases of normal execution, the `evaluation details` structure's `variant` field MUST contain the value of the `variant` field in the `flag resolution` structure returned by the configured `provider`, if the field is set.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 1.14",
-            "machine_id": "requirement_1_14",
+            "id": "Requirement 1.4.6",
+            "machine_id": "requirement_1_4_6",
             "content": "In cases of normal execution, the `evaluation details` structure's `reason` field MUST contain the value of the `reason` field in the `flag resolution` structure returned by the configured `provider`, if the field is set.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 1.15",
-            "machine_id": "requirement_1_15",
+            "id": "Requirement 1.4.7",
+            "machine_id": "requirement_1_4_7",
             "content": "In cases of abnormal execution, the `evaluation details` structure's `error code` field MUST identify an error occurred during flag evaluation, having possible values `\"PROVIDER_NOT_READY\"`, `\"FLAG_NOT_FOUND\"`, `\"PARSE_ERROR\"`, `\"TYPE_MISMATCH\"`, or `\"GENERAL\"`.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 1.16",
-            "machine_id": "requirement_1_16",
+            "id": "Requirement 1.4.8",
+            "machine_id": "requirement_1_4_8",
             "content": "In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field in the `evaluation details` SHOULD indicate an error.",
             "RFC 2119 keyword": "SHOULD",
             "children": []
         },
         {
-            "id": "Requirement 1.17",
-            "machine_id": "requirement_1_17",
-            "content": "The `evaluation options` structure's `hooks` field denotes a collection of hooks that the client MUST execute for the respective flag evaluation, in addition to those already configured.",
-            "RFC 2119 keyword": "MUST",
-            "children": []
-        },
-        {
-            "id": "Requirement 1.18",
-            "machine_id": "requirement_1_18",
-            "content": "Methods, functions, or operations on the client MUST NOT throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup.",
+            "id": "Requirement 1.4.9",
+            "machine_id": "requirement_1_4_9",
+            "content": "Methods, functions, or operations on the client MUST NOT throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup, and user-defined code such as hooks.",
             "RFC 2119 keyword": "MUST NOT",
             "children": []
         },
         {
-            "id": "Requirement 1.19",
-            "machine_id": "requirement_1_19",
+            "id": "Requirement 1.4.10",
+            "machine_id": "requirement_1_4_10",
             "content": "In the case of abnormal execution, the client SHOULD log an informative error message.",
             "RFC 2119 keyword": "SHOULD",
             "children": []
         },
         {
-            "id": "Requirement 1.20",
-            "machine_id": "requirement_1_20",
+            "id": "Requirement 1.4.11",
+            "machine_id": "requirement_1_4_11",
             "content": "The `client` SHOULD provide asynchronous or non-blocking mechanisms for flag evaluation.",
             "RFC 2119 keyword": "SHOULD",
             "children": []
         },
         {
-            "id": "Requirement 1.21",
-            "machine_id": "requirement_1_21",
+            "id": "Requirement 1.5.1",
+            "machine_id": "requirement_1_5_1",
+            "content": "The `evaluation options` structure's `hooks` field denotes a collection of hooks that the client MUST execute for the respective flag evaluation, in addition to those already configured.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Requirement 1.6.1",
+            "machine_id": "requirement_1_6_1",
             "content": "The `client` SHOULD transform the `evaluation context` using the `provider's` `context transformer` function if one is defined, before passing the result of the transformation to the provider's flag resolution functions.",
             "RFC 2119 keyword": "SHOULD",
             "children": []
@@ -286,16 +286,9 @@
             "children": []
         },
         {
-            "id": "Condition 3.8",
-            "machine_id": "condition_3_8",
-            "content": "`finally` is a reserved word in the language.",
-            "RFC 2119 keyword": null,
-            "children": []
-        },
-        {
             "id": "Requirement 4.1.1",
             "machine_id": "requirement_4_1_1",
-            "content": "Hook context MUST provide: the flag key, flag type, evaluation context, and the default value.",
+            "content": "Hook context MUST provide: the `flag key`, `flag value type`, `evaluation context`, and the `default value`.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -309,7 +302,7 @@
         {
             "id": "Requirement 4.1.3",
             "machine_id": "requirement_4_1_3",
-            "content": "flag key, flag type, default value properties MUST be immutable. If the language does not support immutability, the hook MUST NOT modify these properties.",
+            "content": "The `flag key`, `flag type`, and `default value` properties MUST be immutable. If the language does not support immutability, the hook **MUST NOT** modify these properties.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -323,7 +316,7 @@
         {
             "id": "Requirement 4.2.1",
             "machine_id": "requirement_4_2_1",
-            "content": "HookHints MUST be a map of objects.",
+            "content": "HookHints MUST be a structure supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean | string | number | datetime | structure`..",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -344,7 +337,7 @@
         {
             "id": "Requirement 4.3.2",
             "machine_id": "requirement_4_3_2",
-            "content": "The `before` stage MUST run before flag evaluation occurs. It accepts a `hook context` (required) and `HookHints` (optional) as parameters and returns either an `EvaluationContext` or nothing.",
+            "content": "The `before` stage MUST run before flag resolution occurs. It accepts a `hook context` (required) and `HookHints` (optional) as parameters and returns either an `EvaluationContext` or nothing.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -358,21 +351,21 @@
         {
             "id": "Requirement 4.3.4",
             "machine_id": "requirement_4_3_4",
-            "content": "When `before` hooks have finished executing, any resulting `EvaluationContext` MUST be merged with the invocation `EvaluationContext` with the invocation `EvaluationContext` taking precedence in the case of any conflicts.",
+            "content": "When `before` hooks have finished executing, any resulting `EvaluationContext`  MUST be merged with the invocation `EvaluationContext` with the invocation `EvaluationContext` taking precedence in the case of any conflicts.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.3.5",
             "machine_id": "requirement_4_3_5",
-            "content": "The `after` stage MUST run after flag evaluation occurs. It accepts a `hook context` (required), `flag evaluation details` (required) and `HookHints` (optional). It has no return value.",
+            "content": "The `after` stage MUST run after flag resolution occurs. It accepts a `hook context` (required), `flag evaluation details` (required) and `HookHints` (optional). It has no return value.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.3.6",
             "machine_id": "requirement_4_3_6",
-            "content": "The `error` hook MUST run when errors are encountered in the `before` stage, the `after` stage or during flag evaluation. It accepts `hook context` (required), `exception` for what went wrong (required), and `HookHints` (optional). It has no return value.",
+            "content": "The `error` hook MUST run when errors are encountered in the `before` stage, the `after` stage or during flag resolution. It accepts `hook context (required), `exception`for what went wrong (required), and`HookHints` (optional). It has no return value.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -381,6 +374,13 @@
             "machine_id": "requirement_4_3_7",
             "content": "The `finally` hook MUST run after the `before`, `after`, and `error` stages. It accepts a `hook context` (required) and `HookHints` (optional). There is no return value.",
             "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Condition 4.3.8",
+            "machine_id": "condition_4_3_8",
+            "content": "`finally` is a reserved word in the language.",
+            "RFC 2119 keyword": null,
             "children": []
         },
         {
@@ -407,49 +407,42 @@
         {
             "id": "Requirement 4.4.4",
             "machine_id": "requirement_4_4_4",
-            "content": "If an error occurs in the `before` or `after` hooks, the `error` hooks MUST be invoked.",
+            "content": "If an error is encountered in `error` stage, it MUST be returned to the application author.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.4.5",
             "machine_id": "requirement_4_4_5",
-            "content": "If an error occurs during the evaluation of `before` or `after` hooks, any remaining hooks in the `before` or `after` stages MUST NOT be invoked.",
-            "RFC 2119 keyword": "MUST NOT",
+            "content": "If an error occurs in the `before` or `after` hooks, the `error` hooks MUST be invoked.",
+            "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.4.6",
             "machine_id": "requirement_4_4_6",
-            "content": "If an error is encountered in the error stage, it MUST NOT be returned to the user.",
+            "content": "If an error occurs during the evaluation of `before` or `after` hooks, any remaining hooks in the `before` or `after` stages MUST NOT be invoked.",
             "RFC 2119 keyword": "MUST NOT",
             "children": []
         },
         {
             "id": "Requirement 4.5.1",
             "machine_id": "requirement_4_5_1",
-            "content": "`Flag evalution options` MUST contain a list of hooks to evaluate.",
-            "RFC 2119 keyword": "MUST",
-            "children": []
-        },
-        {
-            "id": "Requirement 4.5.2",
-            "machine_id": "requirement_4_5_2",
             "content": "`Flag evaluation options` MAY contain `HookHints`, a map of data to be provided to hook invocations.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },
         {
-            "id": "Requirement 4.5.3",
-            "machine_id": "requirement_4_5_3",
+            "id": "Requirement 4.5.2",
+            "machine_id": "requirement_4_5_2",
             "content": "`HookHints` MUST be passed to each hook.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 4.5.4",
-            "machine_id": "requirement_4_5_4",
-            "content": "The hook MUST NOT alter the `HookHints` object.",
+            "id": "Requirement 4.5.3",
+            "machine_id": "requirement_4_5_3",
+            "content": "The hook MUST NOT alter the `HookHints` structure.",
             "RFC 2119 keyword": "MUST NOT",
             "children": []
         }

--- a/specification.json
+++ b/specification.json
@@ -138,7 +138,7 @@
         {
             "id": "Requirement 1.4.9",
             "machine_id": "requirement_1_4_9",
-            "content": "Methods, functions, or operations on the client MUST NOT throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup, and user-defined code such as hooks.",
+            "content": "Methods, functions, or operations on the client MUST NOT throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup.",
             "RFC 2119 keyword": "MUST NOT",
             "children": []
         },
@@ -337,42 +337,42 @@
         {
             "id": "Requirement 4.3.2",
             "machine_id": "requirement_4_3_2",
-            "content": "The `before` stage MUST run before flag resolution occurs. It accepts a `hook context` (required) and `HookHints` (optional) as parameters and returns either an `EvaluationContext` or nothing.",
+            "content": "The `before` stage MUST run before flag resolution occurs. It accepts a `hook context` (required) and `hook hints` (optional) as parameters and returns either an `evaluation context` or nothing.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.3.3",
             "machine_id": "requirement_4_3_3",
-            "content": "Any `EvaluationContext` returned from a `before` hook MUST be passed to subsequent `before` hooks (via `HookContext`).",
+            "content": "Any `evaluation context` returned from a `before` hook MUST be passed to subsequent `before` hooks (via `HookContext`).",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.3.4",
             "machine_id": "requirement_4_3_4",
-            "content": "When `before` hooks have finished executing, any resulting `EvaluationContext` MUST be merged with the invocation `EvaluationContext` with the invocation `EvaluationContext` taking precedence in the case of any conflicts.",
+            "content": "When `before` hooks have finished executing, any resulting `evaluation context` MUST be merged with the invocation `evaluation context` with the invocation `evaluation context` taking precedence in the case of any conflicts.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.3.5",
             "machine_id": "requirement_4_3_5",
-            "content": "The `after` stage MUST run after flag resolution occurs. It accepts a `hook context` (required), `flag evaluation details` (required) and `HookHints` (optional). It has no return value.",
+            "content": "The `after` stage MUST run after flag resolution occurs. It accepts a `hook context` (required), `flag evaluation details` (required) and `hook hints` (optional). It has no return value.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.3.6",
             "machine_id": "requirement_4_3_6",
-            "content": "The `error` hook MUST run when errors are encountered in the `before` stage, the `after` stage or during flag resolution. It accepts `hook context (required), `exception`for what went wrong (required), and`HookHints` (optional). It has no return value.",
+            "content": "The `error` hook MUST run when errors are encountered in the `before` stage, the `after` stage or during flag resolution. It accepts `hook context` (required), `exception` representing what went wrong (required), and `hook hints` (optional). It has no return value.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.3.7",
             "machine_id": "requirement_4_3_7",
-            "content": "The `finally` hook MUST run after the `before`, `after`, and `error` stages. It accepts a `hook context` (required) and `HookHints` (optional). There is no return value.",
+            "content": "The `finally` hook MUST run after the `before`, `after`, and `error` stages. It accepts a `hook context` (required) and `hook hints` (optional). There is no return value.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -408,15 +408,15 @@
         {
             "id": "Requirement 4.4.3",
             "machine_id": "requirement_4_4_3",
-            "content": "If an error occurs in the `finally` hook, it MUST NOT trigger the `error` hook.",
-            "RFC 2119 keyword": "MUST NOT",
+            "content": "If a `finally` hook abnormally terminates, evaluation should proceed normally, including the execution of any remaining `finally` hooks.",
+            "RFC 2119 keyword": null,
             "children": []
         },
         {
             "id": "Requirement 4.4.4",
             "machine_id": "requirement_4_4_4",
-            "content": "If an error is encountered in `error` stage, it MUST be returned to the application author.",
-            "RFC 2119 keyword": "MUST",
+            "content": "If an `error` hook abnormally terminates, evaluation should proceed normally, including the execution of any remaining `error` hooks.",
+            "RFC 2119 keyword": null,
             "children": []
         },
         {
@@ -436,21 +436,21 @@
         {
             "id": "Requirement 4.5.1",
             "machine_id": "requirement_4_5_1",
-            "content": "`Flag evaluation options` MAY contain `HookHints`, a map of data to be provided to hook invocations.",
+            "content": "`Flag evaluation options` MAY contain `hook hints`, a map of data to be provided to hook invocations.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },
         {
             "id": "Requirement 4.5.2",
             "machine_id": "requirement_4_5_2",
-            "content": "`HookHints` MUST be passed to each hook.",
+            "content": "`hook hints` MUST be passed to each hook.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.5.3",
             "machine_id": "requirement_4_5_3",
-            "content": "The hook MUST NOT alter the `HookHints` structure.",
+            "content": "The hook MUST NOT alter the `hook hints` structure.",
             "RFC 2119 keyword": "MUST NOT",
             "children": []
         }

--- a/specification.json
+++ b/specification.json
@@ -408,15 +408,15 @@
         {
             "id": "Requirement 4.4.3",
             "machine_id": "requirement_4_4_3",
-            "content": "If a `finally` hook abnormally terminates, evaluation should proceed normally, including the execution of any remaining `finally` hooks.",
-            "RFC 2119 keyword": null,
+            "content": "If a `finally` hook abnormally terminates, evaluation MUST proceed normally, including the execution of any remaining `finally` hooks.",
+            "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.4.4",
             "machine_id": "requirement_4_4_4",
-            "content": "If an `error` hook abnormally terminates, evaluation should proceed normally, including the execution of any remaining `error` hooks.",
-            "RFC 2119 keyword": null,
+            "content": "If an `error` hook abnormally terminates, evaluation MUST proceed normally, including the execution of any remaining `error` hooks.",
+            "RFC 2119 keyword": "MUST",
             "children": []
         },
         {

--- a/specification.json
+++ b/specification.json
@@ -408,14 +408,14 @@
         {
             "id": "Requirement 4.4.3",
             "machine_id": "requirement_4_4_3",
-            "content": "If a `finally` hook abnormally terminates, evaluation MUST proceed normally, including the execution of any remaining `finally` hooks.",
+            "content": "If a `finally` hook abnormally terminates, evaluation MUST proceed, including the execution of any remaining `finally` hooks.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 4.4.4",
             "machine_id": "requirement_4_4_4",
-            "content": "If an `error` hook abnormally terminates, evaluation MUST proceed normally, including the execution of any remaining `error` hooks.",
+            "content": "If an `error` hook abnormally terminates, evaluation MUST proceed, including the execution of any remaining `error` hooks.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -302,7 +302,7 @@
         {
             "id": "Requirement 4.1.3",
             "machine_id": "requirement_4_1_3",
-            "content": "The `flag key`, `flag type`, and `default value` properties MUST be immutable. If the language does not support immutability, the hook **MUST NOT** modify these properties.",
+            "content": "The `flag key`, `flag type`, and `default value` properties MUST be immutable. If the language does not support immutability, the hook MUST NOT modify these properties.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },

--- a/specification/evaluation-context/evaluation-context.md
+++ b/specification/evaluation-context/evaluation-context.md
@@ -4,32 +4,22 @@
 
 ## Overview
 
-The `evaluation context` provides ambient information for the purposes of flag
-evaluation. Contextual data may be used as the basis for targeting, including
-rule-based evaluation, overrides for specific subjects, or fractional flag
-evaluation.
+The `evaluation context` provides ambient information for the purposes of flag evaluation. Contextual data may be used as the basis for targeting, including rule-based evaluation, overrides for specific subjects, or fractional flag evaluation.
 
 ### Fields
 
-NOTE: Field casing is not specified, and should be chosen in accordance with
-language idioms.
+NOTE: Field casing is not specified, and should be chosen in accordance with language idioms.
 
 see: [types](../types.md)
 
 ##### Requirement 3.1
 
-> The `evaluation context` structure **MUST** define an optional `targeting key`
-> field of type string, identifying the subject of the flag evaluation.
+> The `evaluation context` structure **MUST** define an optional `targeting key` field of type string, identifying the subject of the flag evaluation.
 
-The targeting key uniquely identifies the subject (end-user, or client service)
-of a flag evaluation. Providers may require this field for fractional flag
-evaluation, rules, or overrides targeting specific users. Such providers may
-behave unpredictably if a targeting key is not specified at flag resolution.
+The targeting key uniquely identifies the subject (end-user, or client service) of a flag evaluation. Providers may require this field for fractional flag evaluation, rules, or overrides targeting specific users. Such providers may behave unpredictably if a targeting key is not specified at flag resolution.
 
 ##### Requirement 3.2
 
-> The evaluation context **MUST** support the inclusion of custom fields, having
-> keys of type `string`, and values of type
-> `boolean | string | number | datetime | structure`.
+> The evaluation context **MUST** support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | datetime | structure`.
 
 see: [structure](../types.md#structure), [datetime](../types.md#datetime)

--- a/specification/flag-evaluation/flag-evaluation.md
+++ b/specification/flag-evaluation/flag-evaluation.md
@@ -4,29 +4,19 @@
 
 ## Overview
 
-The `evaluation API` allows for the evaluation of feature flag values,
-independent of any flag control plane or vendor. In the absence of a
-[provider](../provider/providers.md) the `evaluation API` uses the "No-op
-provider", which simply returns the supplied default flag value.
+The `evaluation API` allows for the evaluation of feature flag values, independent of any flag control plane or vendor. In the absence of a [provider](../provider/providers.md) the `evaluation API` uses the "No-op provider", which simply returns the supplied default flag value.
 
 ### API Initialization and Configuration
 
 #### Requirement 1.1.1
 
-> The `API`, and any state it maintains **SHOULD** exist as a global singleton,
-> even in cases wherein multiple versions of the `API` are present at runtime.
+> The `API`, and any state it maintains **SHOULD** exist as a global singleton, even in cases wherein multiple versions of the `API` are present at runtime.
 
-It's important that multiple instances of the `API` not be active, so that state
-stored therein, such as the registered `provider`, static global
-`evaluation context`, and globally configured `hooks` allow the `API` to behave
-predictably. This can be difficult in some runtimes or languages, but
-implementors should make their best effort to ensure that only a single instance
-of the `API` is used.
+It's important that multiple instances of the `API` not be active, so that state stored therein, such as the registered `provider`, static global `evaluation context`, and globally configured `hooks` allow the `API` to behave predictably. This can be difficult in some runtimes or languages, but implementors should make their best effort to ensure that only a single instance of the `API` is used.
 
 #### Requirement 1.1.2
 
-> The `API` **MUST** provide a function to set the global `provider` singleton,
-> which accepts an API-conformant `provider` implementation.
+> The `API` **MUST** provide a function to set the global `provider` singleton, which accepts an API-conformant `provider` implementation.
 
 ```
 // example provider mutator
@@ -37,9 +27,7 @@ See [provider](../provider//providers.md) for details.
 
 #### Requirement 1.1.3
 
-> The `API` **MUST** provide a function to add `hooks` which accepts one or more
-> API-conformant `hooks`, and appends them to the collection of any previously
-> added hooks. When new hooks are added, previously added hooks are not removed.
+> The `API` **MUST** provide a function to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.
 
 ```
 // example hook attachment
@@ -50,8 +38,7 @@ See [hooks](./hooks.md) for details.
 
 #### Requirement 1.1.4
 
-> The API **MUST** provide a function for retrieving the `provider`
-> implementation.
+> The API **MUST** provide a function for retrieving the `provider` implementation.
 
 ```
 // example provider accessor
@@ -62,8 +49,7 @@ See [provider](../provider/providers.md) for details.
 
 #### Requirement 1.1.5
 
-> The `API` **MUST** provide a function for creating a `client` which accepts
-> the following options:
+> The `API` **MUST** provide a function for creating a `client` which accepts the following options:
 >
 > - name (optional): A logical string identifier for the client.
 
@@ -80,9 +66,7 @@ The name is a logical identifier for the client.
 
 #### Requirement 1.2.1
 
-> The client **MUST** provide a method to add `hooks` which accepts one or more
-> API-conformant `hooks`, and appends them to the collection of any previously
-> added hooks. When new hooks are added, previously added hooks are not removed.
+> The client **MUST** provide a method to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.
 
 ```
 // example hook attachment
@@ -95,10 +79,7 @@ See [hooks](./hooks.md) for details.
 
 ##### Requirement 1.3.1
 
-> The `client` **MUST** provide methods for flag evaluation, with parameters
-> `flag key` (string, required), `default value` (boolean | number | string |
-> structure, required), `evaluation context` (optional), and
-> `evaluation options` (optional), which returns the flag value.
+> The `client` **MUST** provide methods for flag evaluation, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns the flag value.
 
 ```
 // example flag evaluation
@@ -107,13 +88,11 @@ var myValue = client.getValue('my-flag', false);
 
 ##### Condition 1.3.2
 
-> The language type system differentiates between strings, numbers, booleans and
-> structures.
+> The language type system differentiates between strings, numbers, booleans and structures.
 
 ###### Conditional Requirement 1.3.2.1
 
-> The `client` **MUST** provide methods for typed flag evaluation, including
-> boolean, numeric, string, and structure.
+> The `client` **MUST** provide methods for typed flag evaluation, including boolean, numeric, string, and structure.
 
 ```
 // example boolean flag evaluation
@@ -129,26 +108,17 @@ number myNumber = client.getNumberValue('number-flag', 75);
 MyStruct myStruct = client.getObjectValue<MyStruct>('structured-flag', { text: 'N/A', percentage: 75 }, evaluationContext, options);
 ```
 
-See [evaluation context](../evaluation-context/evaluation-context.md) for
-details.
+See [evaluation context](../evaluation-context/evaluation-context.md) for details.
 
 ###### Conditional Requirement 1.3.3
 
-> The `client` **SHOULD** guarantee the returned value of any typed flag
-> evaluation method is of the expected type. If the value returned by the
-> underlying provider implementation does not match the expected type, it's to
-> be considered abnormal execution, and the supplied `default value` should be
-> returned.
+> The `client` **SHOULD** guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied `default value` should be returned.
 
 #### Detailed Flag Evaluation
 
 ##### Requirement 1.4.1
 
-> The `client` **MUST** provide methods for detailed flag value evaluation with
-> parameters `flag key` (string, required), `default value` (boolean | number |
-> string | structure, required), `evaluation context` (optional), and
-> `evaluation options` (optional), which returns an `evaluation details`
-> structure.
+> The `client` **MUST** provide methods for detailed flag value evaluation with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns an `evaluation details` structure.
 
 ```
 // example detailed boolean flag evaluation
@@ -167,8 +137,7 @@ FlagEvaluationDetails<MyStruct> myStructDetails = client.getObjectDetails<MyStru
 
 ##### Requirement 1.4.2
 
-> The `evaluation details` structure's `value` field **MUST** contain the
-> evaluated flag value.
+> The `evaluation details` structure's `value` field **MUST** contain the evaluated flag value.
 
 ##### Condition 1.4.3
 
@@ -176,79 +145,51 @@ FlagEvaluationDetails<MyStruct> myStructDetails = client.getObjectDetails<MyStru
 
 ###### Conditional Requirement 1.4.3.1
 
-> The `evaluation details` structure **SHOULD** accept a generic argument (or
-> use an equivalent language feature) which indicates the type of the wrapped
-> `value` field.
+> The `evaluation details` structure **SHOULD** accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.
 
 ##### Requirement 1.4.4
 
-> The `evaluation details` structure's `flag key` field **MUST** contain the
-> `flag key` argument passed to the detailed flag evaluation method.
+> The `evaluation details` structure's `flag key` field **MUST** contain the `flag key` argument passed to the detailed flag evaluation method.
 
 ##### Requirement 1.4.5
 
-> In cases of normal execution, the `evaluation details` structure's `variant`
-> field **MUST** contain the value of the `variant` field in the
-> `flag resolution` structure returned by the configured `provider`, if the
-> field is set.
+> In cases of normal execution, the `evaluation details` structure's `variant` field **MUST** contain the value of the `variant` field in the `flag resolution` structure returned by the configured `provider`, if the field is set.
 
 ##### Requirement 1.4.6
 
-> In cases of normal execution, the `evaluation details` structure's `reason`
-> field **MUST** contain the value of the `reason` field in the
-> `flag resolution` structure returned by the configured `provider`, if the
-> field is set.
+> In cases of normal execution, the `evaluation details` structure's `reason` field **MUST** contain the value of the `reason` field in the `flag resolution` structure returned by the configured `provider`, if the field is set.
 
 ##### Requirement 1.4.7
 
-> In cases of abnormal execution, the `evaluation details` structure's
-> `error code` field **MUST** identify an error occurred during flag evaluation,
-> having possible values `"PROVIDER_NOT_READY"`, `"FLAG_NOT_FOUND"`,
-> `"PARSE_ERROR"`, `"TYPE_MISMATCH"`, or `"GENERAL"`.
+> In cases of abnormal execution, the `evaluation details` structure's `error code` field **MUST** identify an error occurred during flag evaluation, having possible values `"PROVIDER_NOT_READY"`, `"FLAG_NOT_FOUND"`, `"PARSE_ERROR"`, `"TYPE_MISMATCH"`, or `"GENERAL"`.
 
 ##### Requirement 1.4.8
 
-> In cases of abnormal execution (network failure, unhandled error, etc) the
-> `reason` field in the `evaluation details` **SHOULD** indicate an error.
+> In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field in the `evaluation details` **SHOULD** indicate an error.
 
 ##### Requirement 1.4.9
 
-> Methods, functions, or operations on the client **MUST NOT** throw exceptions,
-> or otherwise abnormally terminate. Flag evaluation calls must always return
-> the `default value` in the event of abnormal execution. Exceptions include
-> functions or methods for the purposes for configuration or setup, and
-> user-defined code such as hooks.
+> Methods, functions, or operations on the client **MUST NOT** throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup, and user-defined code such as hooks.
 
-User-defined code in `error` and `finally` hooks may throw or otherwise
-abnormally terminate. This has the benefit of providing a means of making errors
-optionally "loud" for debugging purposes (errors can be re-thrown in `error`
-hooks, for instance).
+User-defined code in `error` and `finally` hooks may throw or otherwise abnormally terminate. This has the benefit of providing a means of making errors optionally "loud" for debugging purposes (errors can be re-thrown in `error` hooks, for instance).
 
 ##### Requirement 1.4.10
 
-> In the case of abnormal execution, the client **SHOULD** log an informative
-> error message.
+> In the case of abnormal execution, the client **SHOULD** log an informative error message.
 
-Implementations may define a standard logging interface that can be supplied as
-an optional argument to the client creation function, which may wrap standard
-logging functionality of the implementation language.
+Implementations may define a standard logging interface that can be supplied as an optional argument to the client creation function, which may wrap standard logging functionality of the implementation language.
 
 ##### Requirement 1.4.11
 
-> The `client` **SHOULD** provide asynchronous or non-blocking mechanisms for
-> flag evaluation.
+> The `client` **SHOULD** provide asynchronous or non-blocking mechanisms for flag evaluation.
 
-It's recommended to provide non-blocking mechanisms for flag evaluation,
-particularly in languages or environments wherein there's a single thread of
-execution.
+It's recommended to provide non-blocking mechanisms for flag evaluation, particularly in languages or environments wherein there's a single thread of execution.
 
 #### Evaluation Options
 
 ##### Requirement 1.5.1
 
-> The `evaluation options` structure's `hooks` field denotes a collection of
-> hooks that the client **MUST** execute for the respective flag evaluation, in
-> addition to those already configured.
+> The `evaluation options` structure's `hooks` field denotes a collection of hooks that the client **MUST** execute for the respective flag evaluation, in addition to those already configured.
 
 See [hooks](./hooks.md) for details.
 
@@ -256,9 +197,6 @@ See [hooks](./hooks.md) for details.
 
 ##### Requirement 1.6.1
 
-> The `client` **SHOULD** transform the `evaluation context` using the
-> `provider's` `context transformer` function if one is defined, before passing
-> the result of the transformation to the provider's flag resolution functions.
+> The `client` **SHOULD** transform the `evaluation context` using the `provider's` `context transformer` function if one is defined, before passing the result of the transformation to the provider's flag resolution functions.
 
-See [context transformation](../provider/providers.md#context-transformation)
-for details.
+See [context transformation](../provider/providers.md#context-transformation) for details.

--- a/specification/flag-evaluation/flag-evaluation.md
+++ b/specification/flag-evaluation/flag-evaluation.md
@@ -11,7 +11,7 @@ provider", which simply returns the supplied default flag value.
 
 ### API Initialization and Configuration
 
-#### Requirement 1.1
+#### Requirement 1.1.1
 
 > The `API`, and any state it maintains **SHOULD** exist as a global singleton,
 > even in cases wherein multiple versions of the `API` are present at runtime.
@@ -23,7 +23,7 @@ predictably. This can be difficult in some runtimes or languages, but
 implementors should make their best effort to ensure that only a single instance
 of the `API` is used.
 
-#### Requirement 1.2
+#### Requirement 1.1.2
 
 > The `API` **MUST** provide a function to set the global `provider` singleton,
 > which accepts an API-conformant `provider` implementation.
@@ -35,7 +35,7 @@ OpenFeature.setProvider(new MyProvider());
 
 See [provider](../provider//providers.md) for details.
 
-#### Requirement 1.3
+#### Requirement 1.1.3
 
 > The `API` **MUST** provide a function to add `hooks` which accepts one or more
 > API-conformant `hooks`, and appends them to the collection of any previously
@@ -48,7 +48,7 @@ OpenFeature.addHooks([new MyHook()]);
 
 See [hooks](./hooks.md) for details.
 
-#### Requirement 1.4
+#### Requirement 1.1.4
 
 > The API **MUST** provide a function for retrieving the `provider`
 > implementation.
@@ -60,7 +60,7 @@ OpenFeature.getProvider();
 
 See [provider](../provider/providers.md) for details.
 
-#### Requirement 1.5
+#### Requirement 1.1.5
 
 > The `API` **MUST** provide a function for creating a `client` which accepts
 > the following options:
@@ -78,7 +78,7 @@ The name is a logical identifier for the client.
 
 ### Client Usage
 
-#### Requirement 1.6
+#### Requirement 1.2.1
 
 > The client **MUST** provide a method to add `hooks` which accepts one or more
 > API-conformant `hooks`, and appends them to the collection of any previously
@@ -93,7 +93,7 @@ See [hooks](./hooks.md) for details.
 
 #### Flag Evaluation
 
-##### Requirement 1.7
+##### Requirement 1.3.1
 
 > The `client` **MUST** provide methods for flag evaluation, with parameters
 > `flag key` (string, required), `default value` (boolean | number | string |
@@ -105,12 +105,12 @@ See [hooks](./hooks.md) for details.
 var myValue = client.getValue('my-flag', false);
 ```
 
-##### Condition 1.8
+##### Condition 1.3.2
 
 > The language type system differentiates between strings, numbers, booleans and
 > structures.
 
-###### Conditional Requirement 1.8.1
+###### Conditional Requirement 1.3.2.1
 
 > The `client` **MUST** provide methods for typed flag evaluation, including
 > boolean, numeric, string, and structure.
@@ -132,7 +132,7 @@ MyStruct myStruct = client.getObjectValue<MyStruct>('structured-flag', { text: '
 See [evaluation context](../evaluation-context/evaluation-context.md) for
 details.
 
-###### Conditional Requirement 1.8.2
+###### Conditional Requirement 1.3.3
 
 > The `client` **SHOULD** guarantee the returned value of any typed flag
 > evaluation method is of the expected type. If the value returned by the
@@ -142,7 +142,7 @@ details.
 
 #### Detailed Flag Evaluation
 
-##### Requirement 1.9
+##### Requirement 1.4.1
 
 > The `client` **MUST** provide methods for detailed flag value evaluation with
 > parameters `flag key` (string, required), `default value` (boolean | number |
@@ -165,68 +165,66 @@ FlagEvaluationDetails<MyStruct> myStructDetails = client.getObjectDetails<MyStru
 
 ```
 
-##### Requirement 1.10
+##### Requirement 1.4.2
 
 > The `evaluation details` structure's `value` field **MUST** contain the
 > evaluated flag value.
 
-##### Condition 1.11
+##### Condition 1.4.3
 
 > The language supports generics (or an equivalent feature).
 
-###### Conditional Requirement 1.11.1
+###### Conditional Requirement 1.4.3.1
 
 > The `evaluation details` structure **SHOULD** accept a generic argument (or
 > use an equivalent language feature) which indicates the type of the wrapped
 > `value` field.
 
-##### Requirement 1.12
+##### Requirement 1.4.4
 
 > The `evaluation details` structure's `flag key` field **MUST** contain the
 > `flag key` argument passed to the detailed flag evaluation method.
 
-##### Requirement 1.13
+##### Requirement 1.4.5
 
 > In cases of normal execution, the `evaluation details` structure's `variant`
 > field **MUST** contain the value of the `variant` field in the
 > `flag resolution` structure returned by the configured `provider`, if the
 > field is set.
 
-##### Requirement 1.14
+##### Requirement 1.4.6
 
 > In cases of normal execution, the `evaluation details` structure's `reason`
 > field **MUST** contain the value of the `reason` field in the
 > `flag resolution` structure returned by the configured `provider`, if the
 > field is set.
 
-##### Requirement 1.15
+##### Requirement 1.4.7
 
 > In cases of abnormal execution, the `evaluation details` structure's
 > `error code` field **MUST** identify an error occurred during flag evaluation,
 > having possible values `"PROVIDER_NOT_READY"`, `"FLAG_NOT_FOUND"`,
 > `"PARSE_ERROR"`, `"TYPE_MISMATCH"`, or `"GENERAL"`.
 
-##### Requirement 1.16
+##### Requirement 1.4.8
 
 > In cases of abnormal execution (network failure, unhandled error, etc) the
 > `reason` field in the `evaluation details` **SHOULD** indicate an error.
 
-##### Requirement 1.17
-
-> The `evaluation options` structure's `hooks` field denotes a collection of
-> hooks that the client **MUST** execute for the respective flag evaluation, in
-> addition to those already configured.
-
-See [hooks](./hooks.md) for details.
-
-##### Requirement 1.18
+##### Requirement 1.4.9
 
 > Methods, functions, or operations on the client **MUST NOT** throw exceptions,
 > or otherwise abnormally terminate. Flag evaluation calls must always return
 > the `default value` in the event of abnormal execution. Exceptions include
-> functions or methods for the purposes for configuration or setup.
+> functions or methods for the purposes for configuration or setup, and
+> user-defined code such as hooks.
 
-##### Requirement 1.19
+User-defined code in `error` and `finally` hooks may throw or otherwise
+abnormally terminate. This has the benefit of providing a means of making errors
+optionally "loud" for debugging purposes (errors can be re-thrown in `error`
+hooks, for instance).
+
+##### Requirement 1.4.10
 
 > In the case of abnormal execution, the client **SHOULD** log an informative
 > error message.
@@ -235,7 +233,7 @@ Implementations may define a standard logging interface that can be supplied as
 an optional argument to the client creation function, which may wrap standard
 logging functionality of the implementation language.
 
-##### Requirement 1.20
+##### Requirement 1.4.11
 
 > The `client` **SHOULD** provide asynchronous or non-blocking mechanisms for
 > flag evaluation.
@@ -244,7 +242,19 @@ It's recommended to provide non-blocking mechanisms for flag evaluation,
 particularly in languages or environments wherein there's a single thread of
 execution.
 
-##### Requirement 1.21
+#### Evaluation Options
+
+##### Requirement 1.5.1
+
+> The `evaluation options` structure's `hooks` field denotes a collection of
+> hooks that the client **MUST** execute for the respective flag evaluation, in
+> addition to those already configured.
+
+See [hooks](./hooks.md) for details.
+
+#### Context Transformation
+
+##### Requirement 1.6.1
 
 > The `client` **SHOULD** transform the `evaluation context` using the
 > `provider's` `context transformer` function if one is defined, before passing

--- a/specification/flag-evaluation/flag-evaluation.md
+++ b/specification/flag-evaluation/flag-evaluation.md
@@ -189,7 +189,7 @@ It's recommended to provide non-blocking mechanisms for flag evaluation, particu
 
 ##### Requirement 1.5.1
 
-> The `evaluation options` structure's `hooks` field denotes a collection of hooks that the client **MUST** execute for the respective flag evaluation, in addition to those already configured.
+> The `evaluation options` structure's `hooks` field denotes an ordered collection of hooks that the client **MUST** execute for the respective flag evaluation, in addition to those already configured.
 
 See [hooks](./hooks.md) for details.
 

--- a/specification/flag-evaluation/flag-evaluation.md
+++ b/specification/flag-evaluation/flag-evaluation.md
@@ -169,9 +169,9 @@ FlagEvaluationDetails<MyStruct> myStructDetails = client.getObjectDetails<MyStru
 
 ##### Requirement 1.4.9
 
-> Methods, functions, or operations on the client **MUST NOT** throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup, and user-defined code such as hooks.
+> Methods, functions, or operations on the client **MUST NOT** throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup.
 
-User-defined code in `error` and `finally` hooks may throw or otherwise abnormally terminate. This has the benefit of providing a means of making errors optionally "loud" for debugging purposes (errors can be re-thrown in `error` hooks, for instance).
+Configuration code includes code to set the provider, instantiate providers, and configure the global API object.
 
 ##### Requirement 1.4.10
 

--- a/specification/flag-evaluation/hooks.md
+++ b/specification/flag-evaluation/hooks.md
@@ -62,7 +62,7 @@ EvaluationContext|void before(HookContext, HookHints)
 
 ##### Requirement 4.3.4
 
-> When `before` hooks have finished executing, any resulting `EvaluationContext` > **MUST** be merged with the invocation `EvaluationContext` with the invocation `EvaluationContext` taking precedence in the case of any conflicts.
+> When `before` hooks have finished executing, any resulting `EvaluationContext` **MUST** be merged with the invocation `EvaluationContext` with the invocation `EvaluationContext` taking precedence in the case of any conflicts.
 
 ##### Requirement 4.3.5
 
@@ -79,10 +79,10 @@ EvaluationContext|void before(HookContext, HookHints)
 ##### Condition 4.3.8
 
 > `finally` is a reserved word in the language.
->
-> ##### 4.3.8.1
->
-> Condition: If `finally` is a reserved word in the language, `finallyAfter` > **SHOULD** be used.
+
+###### Conditional Requirement 4.3.8.1
+
+> Instead of `finally`, `finallyAfter` **SHOULD** be used.
 
 ### Hook registration & ordering
 

--- a/specification/flag-evaluation/hooks.md
+++ b/specification/flag-evaluation/hooks.md
@@ -2,17 +2,11 @@
 
 ## Overview
 
-Hooks are a mechanism whereby application developers can add arbitrary behavior
-to flag evaluation. They operate similarly to middleware in many web frameworks.
+Hooks are a mechanism whereby application developers can add arbitrary behavior to flag evaluation. They operate similarly to middleware in many web frameworks.
 
 ### Definitions
 
-**Hook**: Application author/integrator-supplied logic that is called by the
-OpenFeature framework at a specific stage. **Stage**: An explicit portion of the
-flag evaluation lifecycle. e.g. `before` being "before the
-[resolution](../glossary.md#resolving-flag-values) is run. **Invocation**: A
-single call to evaluate a flag. `client.getBooleanValue(..)` is an invocation.
-**API**: The global API singleton.
+**Hook**: Application author/integrator-supplied logic that is called by the OpenFeature framework at a specific stage. **Stage**: An explicit portion of the flag evaluation lifecycle. e.g. `before` being "before the [resolution](../glossary.md#resolving-flag-values) is run. **Invocation**: A single call to evaluate a flag. `client.getBooleanValue(..)` is an invocation. **API**: The global API singleton.
 
 ### Hook context
 
@@ -20,8 +14,7 @@ Hook context exists to provide hooks with information about the invocation.
 
 ##### Requirement 4.1.1
 
-> Hook context **MUST** provide: the `flag key`, `flag value type`,
-> `evaluation context`, and the `default value`.
+> Hook context **MUST** provide: the `flag key`, `flag value type`, `evaluation context`, and the `default value`.
 
 ##### Requirement 4.1.2
 
@@ -29,9 +22,7 @@ Hook context exists to provide hooks with information about the invocation.
 
 ##### Requirement 4.1.3
 
-> The `flag key`, `flag type`, and `default value` properties **MUST** be
-> immutable. If the language does not support immutability, the hook **MUST
-> NOT** modify these properties.
+> The `flag key`, `flag type`, and `default value` properties **MUST** be immutable. If the language does not support immutability, the hook **MUST NOT** modify these properties.
 
 ##### Requirement 4.1.4
 
@@ -41,14 +32,11 @@ Hook context exists to provide hooks with information about the invocation.
 
 ##### Requirement 4.2.1
 
-> HookHints **MUST** be a structure supports definition of arbitrary properties,
-> with keys of type `string`, and values of type
-> `boolean | string | number | datetime | structure`..
+> HookHints **MUST** be a structure supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean | string | number | datetime | structure`..
 
 ##### Condition 4.2.2
 
-> The implementation language supports a mechanism for marking data as
-> immutable.
+> The implementation language supports a mechanism for marking data as immutable.
 
 > ##### 2.2.1
 >
@@ -62,9 +50,7 @@ Hook context exists to provide hooks with information about the invocation.
 
 ##### Requirement 4.3.2
 
-> The `before` stage **MUST** run before flag resolution occurs. It accepts a
-> `hook context` (required) and `HookHints` (optional) as parameters and returns
-> either an `EvaluationContext` or nothing.
+> The `before` stage **MUST** run before flag resolution occurs. It accepts a `hook context` (required) and `HookHints` (optional) as parameters and returns either an `EvaluationContext` or nothing.
 
 ```
 EvaluationContext|void before(HookContext, HookHints)
@@ -72,34 +58,23 @@ EvaluationContext|void before(HookContext, HookHints)
 
 ##### Requirement 4.3.3
 
-> Any `EvaluationContext` returned from a `before` hook **MUST** be passed to
-> subsequent `before` hooks (via `HookContext`).
+> Any `EvaluationContext` returned from a `before` hook **MUST** be passed to subsequent `before` hooks (via `HookContext`).
 
 ##### Requirement 4.3.4
 
-> When `before` hooks have finished executing, any resulting
-> `EvaluationContext` > **MUST** be merged with the invocation
-> `EvaluationContext` with the invocation `EvaluationContext` taking precedence
-> in the case of any conflicts.
+> When `before` hooks have finished executing, any resulting `EvaluationContext` > **MUST** be merged with the invocation `EvaluationContext` with the invocation `EvaluationContext` taking precedence in the case of any conflicts.
 
 ##### Requirement 4.3.5
 
-> The `after` stage **MUST** run after flag resolution occurs. It accepts a
-> `hook context` (required), `flag evaluation details` (required) and
-> `HookHints` (optional). It has no return value.
+> The `after` stage **MUST** run after flag resolution occurs. It accepts a `hook context` (required), `flag evaluation details` (required) and `HookHints` (optional). It has no return value.
 
 ##### Requirement 4.3.6
 
-> The `error` hook **MUST** run when errors are encountered in the `before`
-> stage, the `after` stage or during flag resolution. It accepts
-> `hook context (required), `exception`for what went wrong (required), and`HookHints`
-> (optional). It has no return value.
+> The `error` hook **MUST** run when errors are encountered in the `before` stage, the `after` stage or during flag resolution. It accepts `hook context (required), `exception`for what went wrong (required), and`HookHints` (optional). It has no return value.
 
 ##### Requirement 4.3.7
 
-> The `finally` hook **MUST** run after the `before`, `after`, and `error`
-> stages. It accepts a `hook context` (required) and `HookHints` (optional).
-> There is no return value.
+> The `finally` hook **MUST** run after the `before`, `after`, and `error` stages. It accepts a `hook context` (required) and `HookHints` (optional). There is no return value.
 
 ##### Condition 4.3.8
 
@@ -107,15 +82,13 @@ EvaluationContext|void before(HookContext, HookHints)
 >
 > ##### 4.3.8.1
 >
-> Condition: If `finally` is a reserved word in the language, `finallyAfter` >
-> **SHOULD** be used.
+> Condition: If `finally` is a reserved word in the language, `finallyAfter` > **SHOULD** be used.
 
 ### Hook registration & ordering
 
 ##### Requirement 4.4.1
 
-> The API, Client and invocation **MUST** have a method for registering hooks
-> which accepts `flag evaluation options`
+> The API, Client and invocation **MUST** have a method for registering hooks which accepts `flag evaluation options`
 
 ```js
 OpenFeature.addHooks(new Hook1());
@@ -141,29 +114,23 @@ client.getValue('my-flag', 'defaultValue', new Hook3());
 
 ##### Requirement 4.4.3
 
-> If an error occurs in the `finally` hook, it **MUST NOT** trigger the `error`
-> hook.
+> If an error occurs in the `finally` hook, it **MUST NOT** trigger the `error` hook.
 
-In practice, this means that abnormal termination in the finally hook will be
-exposed to the application author.
+In practice, this means that abnormal termination in the finally hook will be exposed to the application author.
 
 ##### Requirement 4.4.4
 
-> If an error is encountered in `error` stage, it **MUST** be returned to the
-> application author.
+> If an error is encountered in `error` stage, it **MUST** be returned to the application author.
 
-In practice, this means that abnormal termination in the error hook will be
-exposed to the application author.
+In practice, this means that abnormal termination in the error hook will be exposed to the application author.
 
 ##### Requirement 4.4.5
 
-> If an error occurs in the `before` or `after` hooks, the `error` hooks
-> **MUST** be invoked.
+> If an error occurs in the `before` or `after` hooks, the `error` hooks **MUST** be invoked.
 
 ##### Requirement 4.4.6
 
-> If an error occurs during the evaluation of `before` or `after` hooks, any
-> remaining hooks in the `before` or `after` stages **MUST NOT** be invoked.
+> If an error occurs during the evaluation of `before` or `after` hooks, any remaining hooks in the `before` or `after` stages **MUST NOT** be invoked.
 
 ### [Flag evaluation options](../types.md#evaluation-options)
 
@@ -180,8 +147,7 @@ See: [Flag evaluation options](../flag-evaluation/flag-evaluation.md#)
 
 ##### Requirement 4.5.1
 
-> `Flag evaluation options` **MAY** contain `HookHints`, a map of data to be
-> provided to hook invocations.
+> `Flag evaluation options` **MAY** contain `HookHints`, a map of data to be provided to hook invocations.
 
 ##### Requirement 4.5.2
 

--- a/specification/flag-evaluation/hooks.md
+++ b/specification/flag-evaluation/hooks.md
@@ -114,13 +114,13 @@ client.getValue('my-flag', 'defaultValue', new Hook3());
 
 ##### Requirement 4.4.3
 
-> If a `finally` hook abnormally terminates, evaluation should proceed normally, including the execution of any remaining `finally` hooks.
+> If a `finally` hook abnormally terminates, evaluation **MUST** proceed normally, including the execution of any remaining `finally` hooks.
 
 In languages with try/catch semantics, this means that exceptions thrown in `finally` hooks should be caught, and not propagated up the call stack.
 
 ##### Requirement 4.4.4
 
-> If an `error` hook abnormally terminates, evaluation should proceed normally, including the execution of any remaining `error` hooks.
+> If an `error` hook abnormally terminates, evaluation **MUST** proceed normally, including the execution of any remaining `error` hooks.
 
 In languages with try/catch semantics, this means that exceptions thrown in `error` hooks should be caught, and not propagated up the call stack.
 

--- a/specification/flag-evaluation/hooks.md
+++ b/specification/flag-evaluation/hooks.md
@@ -114,13 +114,13 @@ client.getValue('my-flag', 'defaultValue', new Hook3());
 
 ##### Requirement 4.4.3
 
-> If a `finally` hook abnormally terminates, evaluation **MUST** proceed normally, including the execution of any remaining `finally` hooks.
+> If a `finally` hook abnormally terminates, evaluation **MUST** proceed, including the execution of any remaining `finally` hooks.
 
 In languages with try/catch semantics, this means that exceptions thrown in `finally` hooks should be caught, and not propagated up the call stack.
 
 ##### Requirement 4.4.4
 
-> If an `error` hook abnormally terminates, evaluation **MUST** proceed normally, including the execution of any remaining `error` hooks.
+> If an `error` hook abnormally terminates, evaluation **MUST** proceed, including the execution of any remaining `error` hooks.
 
 In languages with try/catch semantics, this means that exceptions thrown in `error` hooks should be caught, and not propagated up the call stack.
 

--- a/specification/flag-evaluation/hooks.md
+++ b/specification/flag-evaluation/hooks.md
@@ -9,18 +9,19 @@ to flag evaluation. They operate similarly to middleware in many web frameworks.
 
 **Hook**: Application author/integrator-supplied logic that is called by the
 OpenFeature framework at a specific stage. **Stage**: An explicit portion of the
-flag evaluation lifecycle. e.g. `before` being "before the evaluation is run.
-**Invocation**: A single call to evaluate a flag. `client.getBooleanValue(..)`
-is an invocation. **API**: The global API singleton.
+flag evaluation lifecycle. e.g. `before` being "before the
+[resolution](../glossary.md#resolving-flag-values) is run. **Invocation**: A
+single call to evaluate a flag. `client.getBooleanValue(..)` is an invocation.
+**API**: The global API singleton.
 
 ### Hook context
 
 Hook context exists to provide hooks with information about the invocation.
 
-###### Requirement 4.1.1
+##### Requirement 4.1.1
 
-> Hook context **MUST** provide: the flag key, flag type, evaluation context,
-> and the default value.
+> Hook context **MUST** provide: the `flag key`, `flag value type`,
+> `evaluation context`, and the `default value`.
 
 ##### Requirement 4.1.2
 
@@ -28,9 +29,9 @@ Hook context exists to provide hooks with information about the invocation.
 
 ##### Requirement 4.1.3
 
-> flag key, flag type, default value properties **MUST** be immutable. If the
-> language does not support immutability, the hook **MUST NOT** modify these
-> properties.
+> The `flag key`, `flag type`, and `default value` properties **MUST** be
+> immutable. If the language does not support immutability, the hook **MUST
+> NOT** modify these properties.
 
 ##### Requirement 4.1.4
 
@@ -40,13 +41,15 @@ Hook context exists to provide hooks with information about the invocation.
 
 ##### Requirement 4.2.1
 
-> HookHints **MUST** be a map of objects.
+> HookHints **MUST** be a structure supports definition of arbitrary properties,
+> with keys of type `string`, and values of type
+> `boolean | string | number | datetime | structure`..
 
 ##### Condition 4.2.2
 
 > The implementation language supports a mechanism for marking data as
 > immutable.
->
+
 > ##### 2.2.1
 >
 > Condition: HookHints **MUST** be immutable.
@@ -59,7 +62,7 @@ Hook context exists to provide hooks with information about the invocation.
 
 ##### Requirement 4.3.2
 
-> The `before` stage **MUST** run before flag evaluation occurs. It accepts a
+> The `before` stage **MUST** run before flag resolution occurs. It accepts a
 > `hook context` (required) and `HookHints` (optional) as parameters and returns
 > either an `EvaluationContext` or nothing.
 
@@ -74,21 +77,22 @@ EvaluationContext|void before(HookContext, HookHints)
 
 ##### Requirement 4.3.4
 
-> When `before` hooks have finished executing, any resulting `EvaluationContext`
-> **MUST** be merged with the invocation `EvaluationContext` with the invocation
-> `EvaluationContext` taking precedence in the case of any conflicts.
+> When `before` hooks have finished executing, any resulting
+> `EvaluationContext` > **MUST** be merged with the invocation
+> `EvaluationContext` with the invocation `EvaluationContext` taking precedence
+> in the case of any conflicts.
 
 ##### Requirement 4.3.5
 
-> The `after` stage **MUST** run after flag evaluation occurs. It accepts a
+> The `after` stage **MUST** run after flag resolution occurs. It accepts a
 > `hook context` (required), `flag evaluation details` (required) and
 > `HookHints` (optional). It has no return value.
 
 ##### Requirement 4.3.6
 
 > The `error` hook **MUST** run when errors are encountered in the `before`
-> stage, the `after` stage or during flag evaluation. It accepts `hook context`
-> (required), `exception` for what went wrong (required), and `HookHints`
+> stage, the `after` stage or during flag resolution. It accepts
+> `hook context (required), `exception`for what went wrong (required), and`HookHints`
 > (optional). It has no return value.
 
 ##### Requirement 4.3.7
@@ -97,13 +101,13 @@ EvaluationContext|void before(HookContext, HookHints)
 > stages. It accepts a `hook context` (required) and `HookHints` (optional).
 > There is no return value.
 
-##### Condition 3.8
+##### Condition 4.3.8
 
 > `finally` is a reserved word in the language.
 >
-> ##### 3.8.1
+> ##### 4.3.8.1
 >
-> Condition: If `finally` is a reserved word in the language, `finallyAfter`
+> Condition: If `finally` is a reserved word in the language, `finallyAfter` >
 > **SHOULD** be used.
 
 ### Hook registration & ordering
@@ -140,23 +144,26 @@ client.getValue('my-flag', 'defaultValue', new Hook3());
 > If an error occurs in the `finally` hook, it **MUST NOT** trigger the `error`
 > hook.
 
-In practice, this means that errors that occur in the finally hook will bubble
-up.
+In practice, this means that abnormal termination in the finally hook will be
+exposed to the application author.
 
 ##### Requirement 4.4.4
+
+> If an error is encountered in `error` stage, it **MUST** be returned to the
+> application author.
+
+In practice, this means that abnormal termination in the error hook will be
+exposed to the application author.
+
+##### Requirement 4.4.5
 
 > If an error occurs in the `before` or `after` hooks, the `error` hooks
 > **MUST** be invoked.
 
-##### Requirement 4.4.5
+##### Requirement 4.4.6
 
 > If an error occurs during the evaluation of `before` or `after` hooks, any
 > remaining hooks in the `before` or `after` stages **MUST NOT** be invoked.
-
-##### Requirement 4.4.6
-
-> If an error is encountered in the error stage, it **MUST NOT** be returned to
-> the user.
 
 ### [Flag evaluation options](../types.md#evaluation-options)
 
@@ -169,19 +176,17 @@ val = client.get_boolean_value('my-key', False, evaluation_options={
 })
 ```
 
+See: [Flag evaluation options](../flag-evaluation/flag-evaluation.md#)
+
 ##### Requirement 4.5.1
-
-> `Flag evalution options` **MUST** contain a list of hooks to evaluate.
-
-##### Requirement 4.5.2
 
 > `Flag evaluation options` **MAY** contain `HookHints`, a map of data to be
 > provided to hook invocations.
 
-##### Requirement 4.5.3
+##### Requirement 4.5.2
 
 > `HookHints` **MUST** be passed to each hook.
 
-##### Requirement 4.5.4
+##### Requirement 4.5.3
 
-> The hook **MUST NOT** alter the `HookHints` object.
+> The hook **MUST NOT** alter the `HookHints` structure.

--- a/specification/flag-evaluation/hooks.md
+++ b/specification/flag-evaluation/hooks.md
@@ -50,7 +50,7 @@ Hook context exists to provide hooks with information about the invocation.
 
 ##### Requirement 4.3.2
 
-> The `before` stage **MUST** run before flag resolution occurs. It accepts a `hook context` (required) and `HookHints` (optional) as parameters and returns either an `EvaluationContext` or nothing.
+> The `before` stage **MUST** run before flag resolution occurs. It accepts a `hook context` (required) and `hook hints` (optional) as parameters and returns either an `evaluation context` or nothing.
 
 ```
 EvaluationContext|void before(HookContext, HookHints)
@@ -58,23 +58,23 @@ EvaluationContext|void before(HookContext, HookHints)
 
 ##### Requirement 4.3.3
 
-> Any `EvaluationContext` returned from a `before` hook **MUST** be passed to subsequent `before` hooks (via `HookContext`).
+> Any `evaluation context` returned from a `before` hook **MUST** be passed to subsequent `before` hooks (via `HookContext`).
 
 ##### Requirement 4.3.4
 
-> When `before` hooks have finished executing, any resulting `EvaluationContext` **MUST** be merged with the invocation `EvaluationContext` with the invocation `EvaluationContext` taking precedence in the case of any conflicts.
+> When `before` hooks have finished executing, any resulting `evaluation context` **MUST** be merged with the invocation `evaluation context` with the invocation `evaluation context` taking precedence in the case of any conflicts.
 
 ##### Requirement 4.3.5
 
-> The `after` stage **MUST** run after flag resolution occurs. It accepts a `hook context` (required), `flag evaluation details` (required) and `HookHints` (optional). It has no return value.
+> The `after` stage **MUST** run after flag resolution occurs. It accepts a `hook context` (required), `flag evaluation details` (required) and `hook hints` (optional). It has no return value.
 
 ##### Requirement 4.3.6
 
-> The `error` hook **MUST** run when errors are encountered in the `before` stage, the `after` stage or during flag resolution. It accepts `hook context (required), `exception`for what went wrong (required), and`HookHints` (optional). It has no return value.
+> The `error` hook **MUST** run when errors are encountered in the `before` stage, the `after` stage or during flag resolution. It accepts `hook context` (required), `exception` representing what went wrong (required), and `hook hints` (optional). It has no return value.
 
 ##### Requirement 4.3.7
 
-> The `finally` hook **MUST** run after the `before`, `after`, and `error` stages. It accepts a `hook context` (required) and `HookHints` (optional). There is no return value.
+> The `finally` hook **MUST** run after the `before`, `after`, and `error` stages. It accepts a `hook context` (required) and `hook hints` (optional). There is no return value.
 
 ##### Condition 4.3.8
 
@@ -114,15 +114,15 @@ client.getValue('my-flag', 'defaultValue', new Hook3());
 
 ##### Requirement 4.4.3
 
-> If an error occurs in the `finally` hook, it **MUST NOT** trigger the `error` hook.
+> If a `finally` hook abnormally terminates, evaluation should proceed normally, including the execution of any remaining `finally` hooks.
 
-In practice, this means that abnormal termination in the finally hook will be exposed to the application author.
+In languages with try/catch semantics, this means that exceptions thrown in `finally` hooks should be caught, and not propagated up the call stack.
 
 ##### Requirement 4.4.4
 
-> If an error is encountered in `error` stage, it **MUST** be returned to the application author.
+> If an `error` hook abnormally terminates, evaluation should proceed normally, including the execution of any remaining `error` hooks.
 
-In practice, this means that abnormal termination in the error hook will be exposed to the application author.
+In languages with try/catch semantics, this means that exceptions thrown in `error` hooks should be caught, and not propagated up the call stack.
 
 ##### Requirement 4.4.5
 
@@ -147,12 +147,12 @@ See: [Flag evaluation options](../flag-evaluation/flag-evaluation.md#)
 
 ##### Requirement 4.5.1
 
-> `Flag evaluation options` **MAY** contain `HookHints`, a map of data to be provided to hook invocations.
+> `Flag evaluation options` **MAY** contain `hook hints`, a map of data to be provided to hook invocations.
 
 ##### Requirement 4.5.2
 
-> `HookHints` **MUST** be passed to each hook.
+> `hook hints` **MUST** be passed to each hook.
 
 ##### Requirement 4.5.3
 
-> The hook **MUST NOT** alter the `HookHints` structure.
+> The hook **MUST NOT** alter the `hook hints` structure.

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -38,91 +38,61 @@ This document defines some terms that are used across this specification.
 
 ## Feature Flag
 
-A mechanism that allows an Application Author to define alternative codepaths
-within a deployed piece of software, which is conditionally executed at runtime,
-based on a rule set.
+A mechanism that allows an Application Author to define alternative codepaths within a deployed piece of software, which is conditionally executed at runtime, based on a rule set.
 
 ## User Roles
 
 ### Application Author
 
-A developer of an application or service which utilizes the feature flags SDK.
-This person writes code which calls into the SDK to make flagging decisions.
+A developer of an application or service which utilizes the feature flags SDK. This person writes code which calls into the SDK to make flagging decisions.
 
 ### Application Integrator
 
-A developer who is setting up or configuring an application or service to use
-the feature flags SDK. They would write code like "We should speak to the open
-source flagging service, not $vendor" or "The way the system should handle
-telemetry is through $library".
+A developer who is setting up or configuring an application or service to use the feature flags SDK. They would write code like "We should speak to the open source flagging service, not $vendor" or "The way the system should handle telemetry is through $library".
 
 ### Provider Author
 
-The maintainer of an API-compliant [provider](./provider//providers.md) which
-implements the necessary interfaces required for flag evaluation.
+The maintainer of an API-compliant [provider](./provider//providers.md) which implements the necessary interfaces required for flag evaluation.
 
 ### Integration Author
 
-The maintainer of an API-compliant integration which implements additional
-secondary functionality besides flag evaluation.
+The maintainer of an API-compliant integration which implements additional secondary functionality besides flag evaluation.
 
 ### Library Author
 
-The maintainer of a shared library which is a dependency of many applications or
-libraries, which utilizes the feature flags SDK to allow consumers to manage
-library functionality.
+The maintainer of a shared library which is a dependency of many applications or libraries, which utilizes the feature flags SDK to allow consumers to manage library functionality.
 
 ## Common
 
 ### Feature Flag SDK
 
-The libraries used by Application Author to implement feature flags in their
-application or service. The interfaces defined in these libraries adhere to the
-Feature Flag API.
+The libraries used by Application Author to implement feature flags in their application or service. The interfaces defined in these libraries adhere to the Feature Flag API.
 
 ### Feature Flag API
 
-The interfaces and abstractions used by authors (Application, Integration,
-Provider).
+The interfaces and abstractions used by authors (Application, Integration, Provider).
 
-Provider & Integration authors adhere to the API to add support for their
-feature flag implementation or integration. Application authors use it via the
-Feature Flag SDK.
+Provider & Integration authors adhere to the API to add support for their feature flag implementation or integration. Application authors use it via the Feature Flag SDK.
 
 ### Evaluation API
 
-The subset of the [Feature Flag API](#feature-flag-api) that the Application
-Author uses to evaluate flags.
+The subset of the [Feature Flag API](#feature-flag-api) that the Application Author uses to evaluate flags.
 
 ### Flag Management System
 
-A source-of-truth for flag values and rules. Flag management systems may include
-SaaS feature flag vendors, custom "in-house" feature flag infrastructure, or
-open-source implementations.
+A source-of-truth for flag values and rules. Flag management systems may include SaaS feature flag vendors, custom "in-house" feature flag infrastructure, or open-source implementations.
 
 ### Provider
 
-An SDK-compliant implementation which resolves flag values from a particular
-flag management system, allowing the use of the
-[Evaluation API](./flag-evaluation/flag-evaluation.md#flag-evaluation) as an
-abstraction for the system in question.
+An SDK-compliant implementation which resolves flag values from a particular flag management system, allowing the use of the [Evaluation API](./flag-evaluation/flag-evaluation.md#flag-evaluation) as an abstraction for the system in question.
 
 ### Integration
 
-An SDK-compliant secondary function that is abstracted by the Feature Flag API,
-and requires only minimal configuration by the Application Author. Examples
-include telemetry, tracking, custom logging and monitoring.
+An SDK-compliant secondary function that is abstracted by the Feature Flag API, and requires only minimal configuration by the Application Author. Examples include telemetry, tracking, custom logging and monitoring.
 
 ### Evaluation Context
 
-Context object for flag evaluation, which may contain information about the
-runtime environment, details of the transport method encapsulating the flag
-evaluation, the host, the client, the subject (user), etc. This data may be used
-as a basis for differential evaluation of feature flags based on rules that can
-be defined in the flag system. Context data may be provided by merging static
-global context, arguments to flag evaluation, and implicit language-dependant
-state propagation mechanisms (thread-local storage, promise chains,
-continuations, etc).
+Context object for flag evaluation, which may contain information about the runtime environment, details of the transport method encapsulating the flag evaluation, the host, the client, the subject (user), etc. This data may be used as a basis for differential evaluation of feature flags based on rules that can be defined in the flag system. Context data may be provided by merging static global context, arguments to flag evaluation, and implicit language-dependant state propagation mechanisms (thread-local storage, promise chains, continuations, etc).
 
 ### Evaluating Flag Values
 
@@ -134,8 +104,7 @@ The process of retrieving a feature flag value in it's entirety, including:
 
 ### Resolving Flag Values
 
-The process of a provider retrieving a feature flag value from it's particular
-source-of-truth.
+The process of a provider retrieving a feature flag value from it's particular source-of-truth.
 
 ## Flagging specifics
 
@@ -149,19 +118,15 @@ erDiagram
 
 ### Flag
 
-Flags represent a single pivot point of logic. Flags have a type, like `string`,
-`boolean`, `json`, etc. Examples: `redesign_enabled` or `header-order`
+Flags represent a single pivot point of logic. Flags have a type, like `string`, `boolean`, `json`, etc. Examples: `redesign_enabled` or `header-order`
 
 ### Variant
 
-A variant is a semantic identifier for a value. This allows for referral to
-particular values without necessarily including the value itself, which may be
-quite prohibitively large or otherwise unsuitable in some cases.
+A variant is a semantic identifier for a value. This allows for referral to particular values without necessarily including the value itself, which may be quite prohibitively large or otherwise unsuitable in some cases.
 
 ### Values
 
-Individual variants have values associated with them. These values adhere to the
-flag's type. For the `header-order` variants, we may have values like:
+Individual variants have values associated with them. These values adhere to the flag's type. For the `header-order` variants, we may have values like:
 
 ```text
 reverse: [5,4,3,2,1]
@@ -171,15 +136,12 @@ standard: [1,2,3,4,5]
 
 ### Targeting
 
-The application of rules, specific user overrides, or fractional evaluations in
-feature flag resolution.
+The application of rules, specific user overrides, or fractional evaluations in feature flag resolution.
 
 ### Fractional Evaluation
 
-Assigning flag values randomly according to a configured proportion or
-percentage (ie: 50/50).
+Assigning flag values randomly according to a configured proportion or percentage (ie: 50/50).
 
 ### Rule
 
-A rule is some criteria that's used to determine which variant a particular
-context should be mapped to.
+A rule is some criteria that's used to determine which variant a particular context should be mapped to.

--- a/specification/provider/providers.md
+++ b/specification/provider/providers.md
@@ -2,48 +2,36 @@
 
 ## Overview
 
-The `provider` API defines interfaces that Provider Authors can use to abstract
-a particular flag management system, thus enabling the use of the
-`evaluation API` by Application Authors.
+The `provider` API defines interfaces that Provider Authors can use to abstract a particular flag management system, thus enabling the use of the `evaluation API` by Application Authors.
 
 ### Feature Provider Interface
 
 #### Requirement 2.1
 
-> The provider interface **MUST** define a `name` field or accessor, which
-> identifies the provider implementation.
+> The provider interface **MUST** define a `name` field or accessor, which identifies the provider implementation.
 
 #### Flag Value Resolution
 
-`Providers` are implementations of the `feature provider` interface, which may
-wrap vendor SDKs, REST API clients, or otherwise resolve flag values from the
-runtime environment.
+`Providers` are implementations of the `feature provider` interface, which may wrap vendor SDKs, REST API clients, or otherwise resolve flag values from the runtime environment.
 
 ##### Requirement 2.2
 
-> The `feature provider` interface **MUST** define methods to resolve flag
-> values, with parameters `flag key` (string, required), `default value`
-> (boolean | number | string | structure, required), `evaluation context`
-> (optional), and `evaluation options` (optional), which returns a
-> `flag resolution` structure.
+> The `feature provider` interface **MUST** define methods to resolve flag values, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required), `evaluation context` (optional), and `evaluation options` (optional), which returns a `flag resolution` structure.
 
 ```
 // example flag resolution function
 resolveBooleanValue(flagKey, defaultValue, context, options);
 ```
 
-see: [flag resolution structure](../types.md#flag-resolution),
-[flag value resolution](../glossary.md#flag-value-resolution)
+see: [flag resolution structure](../types.md#flag-resolution), [flag value resolution](../glossary.md#flag-value-resolution)
 
 ##### Condition 2.3
 
-> The implementing language type system differentiates between strings, numbers,
-> booleans and structures.
+> The implementing language type system differentiates between strings, numbers, booleans and structures.
 
 ###### Conditional Requirement 2.3.1
 
-> The `feature provider` interface **MUST** define methods for typed flag
-> resolution, including boolean, numeric, string, and structure.
+> The `feature provider` interface **MUST** define methods for typed flag resolution, including boolean, numeric, string, and structure.
 
 ```
 // example boolean flag value resolution
@@ -61,49 +49,31 @@ ResolutionDetails resolveStructureValue(string flagKey, JsonObject defaultValue,
 
 ##### Requirement 2.4
 
-> In cases of normal execution, the `provider` **MUST** populate the
-> `flag resolution` structure's `value` field with the resolved flag value.
+> In cases of normal execution, the `provider` **MUST** populate the `flag resolution` structure's `value` field with the resolved flag value.
 
 ##### Requirement 2.5
 
-> In cases of normal execution, the `provider` **SHOULD** populate the
-> `flag resolution` structure's `variant` field with a string identifier
-> corresponding to the returned flag value.
+> In cases of normal execution, the `provider` **SHOULD** populate the `flag resolution` structure's `variant` field with a string identifier corresponding to the returned flag value.
 
-For example, the flag value might be `3.14159265359`, and the variant field's
-value might be `"pi"`.
+For example, the flag value might be `3.14159265359`, and the variant field's value might be `"pi"`.
 
-The value of the variant field might only be meaningful in the context of the
-flag management system associated with the provider. For example, the variant
-may be a UUID corresponding to the variant in the flag management system, or an
-index corresponding to the variant in the flag management system.
+The value of the variant field might only be meaningful in the context of the flag management system associated with the provider. For example, the variant may be a UUID corresponding to the variant in the flag management system, or an index corresponding to the variant in the flag management system.
 
 ##### Requirement 2.6
 
-> The `provider` **SHOULD** populate the `flag resolution` structure's `reason`
-> field with a string indicating the semantic reason for the returned flag
-> value.
+> The `provider` **SHOULD** populate the `flag resolution` structure's `reason` field with a string indicating the semantic reason for the returned flag value.
 
-Possible values vary by provider, but might include such values as
-`"TARGETING_MATCH"`, `"SPLIT"`, `"DISABLED"`, `"DEFAULT"`, `"UNKNOWN"` or
-`"ERROR"`.
+Possible values vary by provider, but might include such values as `"TARGETING_MATCH"`, `"SPLIT"`, `"DISABLED"`, `"DEFAULT"`, `"UNKNOWN"` or `"ERROR"`.
 
 ##### Requirement 2.7
 
-> In cases of normal execution, the `provider` **MUST NOT** populate the
-> `flag resolution` structure's `error code` field, or otherwise must populate
-> it with a null or falsy value.
+> In cases of normal execution, the `provider` **MUST NOT** populate the `flag resolution` structure's `error code` field, or otherwise must populate it with a null or falsy value.
 
 ##### Requirement 2.8
 
-> In cases of abnormal execution, the `provider` **MUST** indicate an error
-> using the idioms of the implementation language, with an associated error code
-> having possible values `"PROVIDER_NOT_READY"`, `"FLAG_NOT_FOUND"`,
-> `"PARSE_ERROR"`, `"TYPE_MISMATCH"`, or `"GENERAL"`.
+> In cases of abnormal execution, the `provider` **MUST** indicate an error using the idioms of the implementation language, with an associated error code having possible values `"PROVIDER_NOT_READY"`, `"FLAG_NOT_FOUND"`, `"PARSE_ERROR"`, `"TYPE_MISMATCH"`, or `"GENERAL"`.
 
-The provider might throw an exception, return an error, or populate the
-`error code` object on the returned `flag resolution` structure to indicate a
-problem during flag value resolution.
+The provider might throw an exception, return an error, or populate the `error code` object on the returned `flag resolution` structure to indicate a problem during flag value resolution.
 
 ##### Condition 2.9
 
@@ -111,9 +81,7 @@ problem during flag value resolution.
 
 ###### Conditional Requirement 2.9.1
 
-> The `flag resolution` structure **SHOULD** accept a generic argument (or use
-> an equivalent language feature) which indicates the type of the wrapped
-> `value` field.
+> The `flag resolution` structure **SHOULD** accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.
 
 ```
 // example boolean flag value resolution with generic argument
@@ -131,23 +99,15 @@ ResolutionDetails<MyStruct> resolveStructureValue(string flagKey, MyStruct defau
 
 #### Context Transformation
 
-Feature flag management systems often define structures representing arbitrary
-contextual data pertaining to the runtime, user, or application. The context
-transformer defines a simple interface to transform the OpenFeature
-`evaluation context` to such a structure, mapping values appropriately.
+Feature flag management systems often define structures representing arbitrary contextual data pertaining to the runtime, user, or application. The context transformer defines a simple interface to transform the OpenFeature `evaluation context` to such a structure, mapping values appropriately.
 
 See [evaluation context](../evaluation-context/evaluation-context.md).
 
 ##### Requirement 2.10
 
-> The provider interface **MAY** define a `context transformer` method or
-> function, which can be optionally implemented in order to transform the
-> `evaluation context` prior to flag value resolution.
+> The provider interface **MAY** define a `context transformer` method or function, which can be optionally implemented in order to transform the `evaluation context` prior to flag value resolution.
 
-The OpenFeature `client` might apply the transformer function before passing the
-returned value (the `transformed context`) to the provider resolution methods,
-thus allowing the provider implementation to avoid implementing and calling such
-transformation logic repeatedly in flag value resolution methods.
+The OpenFeature `client` might apply the transformer function before passing the returned value (the `transformed context`) to the provider resolution methods, thus allowing the provider implementation to avoid implementing and calling such transformation logic repeatedly in flag value resolution methods.
 
 ```
 class MyProvider implements Provider {
@@ -162,8 +122,7 @@ class MyProvider implements Provider {
 }
 ```
 
-See [evaluation context](../evaluation-context/evaluation-context.md),
-[flag evaluation](./../flag-evaluation/flag-evaluation.md#flag-evaluation).
+See [evaluation context](../evaluation-context/evaluation-context.md), [flag evaluation](./../flag-evaluation/flag-evaluation.md#flag-evaluation).
 
 ##### Condition 2.11
 
@@ -171,12 +130,9 @@ See [evaluation context](../evaluation-context/evaluation-context.md),
 
 ###### Conditional Requirement 2.11.1
 
-> If the implementation includes a `context transformer`, the provider
-> **SHOULD** accept a generic argument (or use an equivalent language feature)
-> indicating the type of the transformed context.
+> If the implementation includes a `context transformer`, the provider **SHOULD** accept a generic argument (or use an equivalent language feature) indicating the type of the transformed context.
 >
-> If such type information is supplied, more accurate type information can be
-> supplied in the flag resolution methods.
+> If such type information is supplied, more accurate type information can be supplied in the flag resolution methods.
 
 ```
 // an example implementation in a language supporting interfaces, classes, and generics

--- a/specification/types.md
+++ b/specification/types.md
@@ -2,13 +2,11 @@
 
 ## Overview
 
-This document outlines some of the common types and data structures defined by
-OpenFeature and referenced elsewhere in this specification.
+This document outlines some of the common types and data structures defined by OpenFeature and referenced elsewhere in this specification.
 
 ### Boolean
 
-A logical true or false, as represented idiomatically in the implementation
-languages.
+A logical true or false, as represented idiomatically in the implementation languages.
 
 ### String
 
@@ -16,27 +14,19 @@ A UTF-8 encoded string.
 
 ### Number
 
-A numeric value of unspecified type or size. Implementation languages may
-further differentiate between integers, floating point numbers, and other
-specific numeric types and provide functionality as idioms dictate.
+A numeric value of unspecified type or size. Implementation languages may further differentiate between integers, floating point numbers, and other specific numeric types and provide functionality as idioms dictate.
 
 ### Structure
 
-Structured data, presented however is idiomatic in the implementation language,
-such as JSON or YAML.
+Structured data, presented however is idiomatic in the implementation language, such as JSON or YAML.
 
 ### Datetime
 
-A language primitive for representing a date and time, including timezone
-information.
+A language primitive for representing a date and time, including timezone information.
 
 ### Evaluation Details
 
-A structure representing the result of the
-[flag evaluation process](./glossary.md#evaluating-flag-values), and made
-available in the
-[detailed flag resolution functions](./flag-evaluation/flag-evaluation.md#detailed-flag-evaluation),
-containing the following fields:
+A structure representing the result of the [flag evaluation process](./glossary.md#evaluating-flag-values), and made available in the [detailed flag resolution functions](./flag-evaluation/flag-evaluation.md#detailed-flag-evaluation), containing the following fields:
 
 - flag key (string, required)
 - value (boolean | string | number | structure, required)
@@ -46,18 +36,14 @@ containing the following fields:
 
 ### Resolution Details
 
-A structure which contains a subset of the fields defined in the
-`evaluation details`, representing the result of the provider's
-[flag resolution process](./glossary.md#resolving-flag-values), including:
+A structure which contains a subset of the fields defined in the `evaluation details`, representing the result of the provider's [flag resolution process](./glossary.md#resolving-flag-values), including:
 
 - value (boolean | string | number | structure, required)
 - error code (string, optional)
 - reason (string, optional)
 - variant (string, optional)
 
-\*NOTE: The `resolution details` structure is not exposed to the Application
-Author. It defines the data which Provider Authors must return when resolving
-the value of flags.
+\*NOTE: The `resolution details` structure is not exposed to the Application Author. It defines the data which Provider Authors must return when resolving the value of flags.
 
 ### Evaluation Options
 

--- a/tools/specification_parser/lint_json_output.py
+++ b/tools/specification_parser/lint_json_output.py
@@ -24,11 +24,11 @@ def main(f):
             for entry in entries:
                 if entry.get('RFC 2119 keyword') is None and \
                    'condition' not in entry['id'].lower():
-                    print(f"{j}: Rule {entry['id']} is missing a RFC 2119 keyword", file=sys.stderr)
+                    print(f"{jsonfile.name}: Rule {entry['id']} is missing a RFC 2119 keyword", file=sys.stderr)
                     errors += 1
                 pass
         except Exception as k:
-            print(f"Non json-spec formatted file found: {j}", file=sys.stderr)
+            print(f"Non json-spec formatted file found: {jsonfile.name}", file=sys.stderr)
 
     sys.exit(errors)
 


### PR DESCRIPTION
This spec has 2 commits, I strongly suggest you look at them one at a time, since the second is purely whitespace changes.

1st commit:

- breaks the flag-evaluation.md doc into sections, more like the hooks.md doc, to prevent so much number thrashing in the future
- improves consistency of terminology across files (see comments)
- specifies that both `error` and `finally` user-defined hooks may throw. This may be controversial, but I think it makes sense (and finally can already throw, as per spec). User-defined code being able to throw seems like a plus too me. See comments.

2nd commit: 

- sets `proseWrap: never` in prettier. This improves readability in PRs. As it stands, the fact that line-wrapping is on adds a lot of unneeded deltas in commits, since adding a new word might totally change the way the wrapping ends up. If we keep everything to a single line, it makes diffing much easier. This is mentioned in the [style guide](https://github.com/open-feature/spec#style-guide)

Fixes #38 