### PR TITLE
Add glossary terms, update errors/examples

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -124,7 +124,7 @@
         {
             "id": "Requirement 1.4.7",
             "machine_id": "requirement_1_4_7",
-            "content": "In cases of abnormal execution, the `evaluation details` structure's `error code` field MUST contain a string identifying an error occurred during flag evaluation, and the nature of the error.",
+            "content": "In cases of abnormal execution, the `evaluation details` structure's `error code` field MUST contain a string identifying an error occurred during flag evaluation and the nature of the error.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -124,7 +124,7 @@
         {
             "id": "Requirement 1.4.7",
             "machine_id": "requirement_1_4_7",
-            "content": "In cases of abnormal execution, the `evaluation details` structure's `error code` field MUST identify an error occurred during flag evaluation, having possible values `\"PROVIDER_NOT_READY\"`, `\"FLAG_NOT_FOUND\"`, `\"PARSE_ERROR\"`, `\"TYPE_MISMATCH\"`, or `\"GENERAL\"`.",
+            "content": "In cases of abnormal execution, the `evaluation details` structure's `error code` field MUST contain a string identifying an error occurred during flag evaluation, and the nature of the error.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },

--- a/specification/flag-evaluation/flag-evaluation.md
+++ b/specification/flag-evaluation/flag-evaluation.md
@@ -161,7 +161,7 @@ FlagEvaluationDetails<MyStruct> myStructDetails = client.getObjectDetails<MyStru
 
 ##### Requirement 1.4.7
 
-> In cases of abnormal execution, the `evaluation details` structure's `error code` field **MUST** contain a string identifying an error occurred during flag evaluation, and the nature of the error.
+> In cases of abnormal execution, the `evaluation details` structure's `error code` field **MUST** contain a string identifying an error occurred during flag evaluation and the nature of the error.
 
 Some example error codes include: `"TARGETING_KEY_MISSING"`, `"PROVIDER_NOT_READY"`, `"FLAG_NOT_FOUND"`, `"PARSE_ERROR"`, `"TYPE_MISMATCH"`, or `"GENERAL"`.
 

--- a/specification/flag-evaluation/flag-evaluation.md
+++ b/specification/flag-evaluation/flag-evaluation.md
@@ -161,7 +161,9 @@ FlagEvaluationDetails<MyStruct> myStructDetails = client.getObjectDetails<MyStru
 
 ##### Requirement 1.4.7
 
-> In cases of abnormal execution, the `evaluation details` structure's `error code` field **MUST** identify an error occurred during flag evaluation, having possible values `"PROVIDER_NOT_READY"`, `"FLAG_NOT_FOUND"`, `"PARSE_ERROR"`, `"TYPE_MISMATCH"`, or `"GENERAL"`.
+> In cases of abnormal execution, the `evaluation details` structure's `error code` field **MUST** contain a string identifying an error occurred during flag evaluation, and the nature of the error.
+
+Some example error codes include: `"TARGETING_KEY_MISSING"`, `"PROVIDER_NOT_READY"`, `"FLAG_NOT_FOUND"`, `"PARSE_ERROR"`, `"TYPE_MISMATCH"`, or `"GENERAL"`.
 
 ##### Requirement 1.4.8
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -120,6 +120,10 @@ erDiagram
 
 Flags represent a single pivot point of logic. Flags have a type, like `string`, `boolean`, `json`, etc. Examples: `redesign_enabled` or `header-order`
 
+### Flag Key
+
+A string logically identifying a particular flag.
+
 ### Variant
 
 A variant is a semantic identifier for a value. This allows for referral to particular values without necessarily including the value itself, which may be quite prohibitively large or otherwise unsuitable in some cases.
@@ -137,6 +141,10 @@ standard: [1,2,3,4,5]
 ### Targeting
 
 The application of rules, specific user overrides, or fractional evaluations in feature flag resolution.
+
+### Targeting Key
+
+A string logically identifying the subject of evaluation (end-user, service, etc).
 
 ### Fractional Evaluation
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -26,9 +26,11 @@ This document defines some terms that are used across this specification.
   - [Resolving Flag Values](#resolving-flag-values)
 - [Flagging specifics](#flagging-specifics)
   - [Flag](#flag)
+  - [Flag Key](#flag-key)
   - [Variant](#variant)
   - [Values](#values)
   - [Targeting](#targeting)
+  - [Targeting Key](#targeting-key)
   - [Fractional Evaluation](#fractional-evaluation)
   - [Rule](#rule)
 


### PR DESCRIPTION
- Updates `error code` definition to clearly be a free form string (as we've discussed previously, and as indicated by the [types specification](https://github.com/open-feature/spec/blob/main/specification/types.md#resolution-details), and adds some examples.

- Adds `targeting key` and `flag key` to glossary.

Fixes: https://github.com/open-feature/spec/issues/82
Fixes: https://github.com/open-feature/spec/issues/50