### PR TITLE
feat: start working on Tracking Events proposal

### DIFF
--- a/specification/events.md
+++ b/specification/events.md
@@ -1,0 +1,38 @@
+# Tracking Events
+
+## Overview
+
+Tracking Events are events that can be emitted by application developers.
+
+### Definitions
+
+TODO
+
+### Emitting Tracking Events
+
+#### Requirement 5.1.1
+
+> The Client **MUST** have a method for emitting Tracking Events and must accept `event tracking options`
+
+```js
+Client client = OpenFeature.getClient();
+`
+//...
+
+client.trackEvent('onboarding-completed', {
+    version: '2022-06-16'
+}, {
+    trackingKey: 'user1'
+});
+```
+### [Event tracking options](./types.md#event-tracking-options)
+
+Usage might looks something like:
+
+```python
+val = client.track_event('my-key', attributes={
+    'version': '2022-06-16'
+}, evaluation_options={
+    'trackingKey': 'user1'
+})
+```

--- a/specification/providers.md
+++ b/specification/providers.md
@@ -157,3 +157,15 @@ interface Provider<T> {
 
 }
 ```
+#### Event Tracking
+
+Feature flag management systems often have functionality to allow sending custom track events related to a user, or application.
+
+##### Requirement 2.2
+
+> The `feature provider` interface **MUST** define a method to emit a event but if the solution provider doesn't support tracking events this can be a no-op.
+
+```typescript
+// example track event function
+trackEvent(eventName, attributes, context);
+```

--- a/specification/types.md
+++ b/specification/types.md
@@ -45,6 +45,11 @@ A structure which contains a subset of the fields defined in the `evaluation det
 
 \*NOTE: The `resolution details` structure is not exposed to the Application Author. It defines the data which Provider Authors must return when resolving the value of flags.
 
+### Event Track Attributes
+
+A structure which contains a set of extranous felds that should be associated
+with the Tracking Event.
+
 ### Evaluation Options
 
 A structure containing the following fields:


### PR DESCRIPTION
A draft proposal for the Tracking Event to allow application developers to emit tracking events which can be useful when their feature flag system to support driving feature flag evaluation by previous events or person properties.

Use case:
Application developer has a dynamic cohort which puts users into  it after they have completed a step in the application, for example the onboarding wizard. A person gets added to the cohort after a specific event has been emitted in relation to the user.

Next a feature flag can be defined which is only active for users in this specific cohort