### PR TITLE
Remove design-principles stub, update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,25 @@
 # OpenFeature Specification (Draft)
 
-[![Roadmap](https://img.shields.io/static/v1?label=Roadmap&message=public&color=green)](https://github.com/orgs/open-feature/projects/1)
-[![Contributing](https://img.shields.io/static/v1?label=Contributing&message=guide&color=blue)](https://github.com/open-feature/.github/blob/main/CONTRIBUTING.md)
-[![Code of Conduct](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/open-feature/.github/blob/main/CODE_OF_CONDUCT.md)
+[![Roadmap](https://img.shields.io/static/v1?label=Roadmap&message=public&color=green)](https://github.com/orgs/open-feature/projects/1) [![Contributing](https://img.shields.io/static/v1?label=Contributing&message=guide&color=blue)](https://github.com/open-feature/.github/blob/main/CONTRIBUTING.md) [![Code of Conduct](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/open-feature/.github/blob/main/CODE_OF_CONDUCT.md)
 
 This repository describes the requirements and expectations for OpenFeature.
 
-> :warning: Ongoing research can be found in the
-> [research repo](https://github.com/open-feature/research). For definitions of
-> key terminology, see the [glossary](./specification/glossary.md).
+> :warning: Ongoing research can be found in the [research repo](https://github.com/open-feature/research). For definitions of key terminology, see the [glossary](./specification/glossary.md).
 
 ## Design Principles
 
-- Compatibility with existing open source and commercial feature flag offerings
-- Simple, understandable API
-- Vendor agnostic
-- First class Kubernetes support
-- Native support for OpenTelemetry
+- Compatibility with existing feature flag offerings
+- Simple, understandable APIs
+- Vendor agnosticism
+- Language agnosticism
+- Low/no dependency
+- Extensibility
 
 ### SDKs and Client Libraries
 
-The project aims to provide a unified API and SDK for feature flag management in
-various technology stacks. The flag evaluation logic will **not** be handled in
-the OpenFeature SDK itself but provide a mechanism for interfacing with an
-external evaluation engine in a vendor agnostic way.
+The project aims to provide a unified API and SDK for feature flag management in various technology stacks. The flag evaluation logic will **not** be handled in the OpenFeature SDK itself but provide a mechanism for interfacing with an external evaluation engine in a vendor agnostic way.
 
-The OpenFeature project will include client libraries for common technology
-stacks including, but not limited to:
+The OpenFeature project will include client libraries for common technology stacks including, but not limited to:
 
 - Golang
 - Java
@@ -34,31 +27,19 @@ stacks including, but not limited to:
 
 ### Tooling
 
-This specification complies with
-[RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) and seeks to conform
-to the [W3C QA Framework Guidelines](https://www.w3.org/TR/qaframe-spec/).
+This specification complies with [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) and seeks to conform to the [W3C QA Framework Guidelines](https://www.w3.org/TR/qaframe-spec/).
 
-In accordance with this, some basic tooling (donated graciously by
-[Diego Hurtado](https://github.com/ocelotl)) has been employed to parse the
-specification and output a JSON structure of concise requirements, highlighting
-the particular `RFC 2119` verb in question.
+In accordance with this, some basic tooling (donated graciously by [Diego Hurtado](https://github.com/ocelotl)) has been employed to parse the specification and output a JSON structure of concise requirements, highlighting the particular `RFC 2119` verb in question.
 
-To parse the specification, simply type `make`. Please review the generated JSON
-files, which will appear as siblings to any of the markdown files in the
-`/specification` folder.
+To parse the specification, simply type `make`. Please review the generated JSON files, which will appear as siblings to any of the markdown files in the `/specification` folder.
 
 ### Style Guide
 
 - Use code blocks for examples.
-  - Code blocks should be pseudocode, not any particular language, but should be
-    vaguely "Java-esque".
-- Use conditional requirements for requirements that only apply in particular
-  situations, such as particular languages or runtimes.
-- Use "sentence case" enclosed in ticks (\`) when identifying entities outside
-  of code blocks (ie: `evaluation details` instead of `EvaluationDetails`).
-- Do not place line breaks into sentences, keep sentences to a single line for
-  easier review.
-- String literals appearing outside of code blocks should be enclosed in both
-  ticks (\`) and double-quotes (") (ie: `"PARSE_ERROR"`).
+  - Code blocks should be pseudocode, not any particular language, but should be vaguely "Java-esque".
+- Use conditional requirements for requirements that only apply in particular situations, such as particular languages or runtimes.
+- Use "sentence case" enclosed in ticks (\`) when identifying entities outside of code blocks (ie: `evaluation details` instead of `EvaluationDetails`).
+- Do not place line breaks into sentences, keep sentences to a single line for easier review.
+- String literals appearing outside of code blocks should be enclosed in both ticks (\`) and double-quotes (") (ie: `"PARSE_ERROR"`).
 - Use "Title Case" for all titles.
 - Use the imperative mood and passive voice.

--- a/specification/README.md
+++ b/specification/README.md
@@ -4,7 +4,6 @@
 
 - [Glossary](./glossary.md)
 - [Types](./types.md)
-- [Design Principles](design-principles.md)
 - [Evaluation API](./flag-evaluation.md)
 - [Providers](./providers.md)
 - [Evaluation Context](./evaluation-context.md)
@@ -16,23 +15,16 @@
 
 The following parts of this document are normative:
 
-- Statements under markdown H5 headings, appearing in markdown block quotes, and
-  containing an uppercase keyword from RFC 2119.
+- Statements under markdown H5 headings, appearing in markdown block quotes, and containing an uppercase keyword from RFC 2119.
 - This conformance clause.
 
 ### Conformance Requirements and Test Assertions
 
-Each [normative section](#normative-sections) defines a single requirement. By
-enumerating these normative sections, a list of test assertions can be derived.
+Each [normative section](#normative-sections) defines a single requirement. By enumerating these normative sections, a list of test assertions can be derived.
 
 ### Compliance
 
-An implementation is not compliant if it fails to satisfy one or more of the
-"MUST", "MUST NOT", "REQUIRED", "SHALL", or "SHALL NOT" requirements defined in
-the [normative sections](#normative-sections) of the specification. Conversely,
-an implementation of the specification is compliant if it satisfies all the
-"MUST", "MUST NOT", "REQUIRED", "SHALL", and "SHALL NOT" requirements defined in
-the [normative sections](#normative-sections) of the specification.
+An implementation is not compliant if it fails to satisfy one or more of the "MUST", "MUST NOT", "REQUIRED", "SHALL", or "SHALL NOT" requirements defined in the [normative sections](#normative-sections) of the specification. Conversely, an implementation of the specification is compliant if it satisfies all the "MUST", "MUST NOT", "REQUIRED", "SHALL", and "SHALL NOT" requirements defined in the [normative sections](#normative-sections) of the specification.
 
 ## Document Statuses
 

--- a/specification/design-principles.md
+++ b/specification/design-principles.md
@@ -1,5 +1,0 @@
-# Design Principles
-
-## Overview
-
-// TODO: this is a stub.


### PR DESCRIPTION
A lot of whitespace/line break changes here. The only actual change is the `Design Principles` section, and removing the link to the "Design Principles" stub.