### PR TITLE
EvaluationContext each key should be unique

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -302,7 +302,7 @@
         {
             "id": "Requirement 3.1.4",
             "machine_id": "requirement_3_1_4",
-            "content": "The evaluation context fields MUST have a unique key.",
+            "content": "The evaluation context fields MUST have an unique key.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -300,17 +300,16 @@
             "children": []
         },
         {
-
-            "id": "Requirement 3.1.4",
-            "machine_id": "requirement_3_1_4",
-            "content": "The evaluation context fields MUST have an unique key.",
+            "id": "Requirement 3.1.3",
+            "machine_id": "requirement_3_1_3",
+            "content": "The evaluation context MUST support fetching the custom fields by key and also fetching all key value pairs.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
-            "id": "Requirement 3.1.3",
-            "machine_id": "requirement_3_1_3",
-            "content": "The evaluation context MUST support fetching the custom fields by key and also fetching all key value pairs.",
+            "id": "Requirement 3.1.4",
+            "machine_id": "requirement_3_1_4",
+            "content": "The evaluation context fields MUST have an unique key.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -300,6 +300,13 @@
             "children": []
         },
         {
+            "id": "Requirement 3.1.4",
+            "machine_id": "requirement_3_1_4",
+            "content": "The evaluation context fields MUST have a unique key.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
             "id": "Requirement 3.2.1",
             "machine_id": "requirement_3_2_1",
             "content": "The API, Client and invocation MUST have a method for supplying `evaluation context`.",

--- a/specification/sections/03-evaluation-context.md
+++ b/specification/sections/03-evaluation-context.md
@@ -30,9 +30,13 @@ The targeting key uniquely identifies the subject (end-user, or client service) 
 
 > The evaluation context **MUST** support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | datetime | structure`.
 
-Each key should be unique.
-
 see: [structure](../types.md#structure), [datetime](../types.md#datetime)
+
+#### Requirement 3.1.4
+
+> The evaluation context fields **MUST** have a unique key.
+
+ The field key uniquely identifies any the field in the `evaluation context` and it should be unique accross all types to avoid any collision when marshelling the `evaluation context` by the provider.
 
 ### Merging Context
 

--- a/specification/sections/03-evaluation-context.md
+++ b/specification/sections/03-evaluation-context.md
@@ -34,9 +34,9 @@ see: [structure](../types.md#structure), [datetime](../types.md#datetime)
 
 #### Requirement 3.1.4
 
-> The evaluation context fields **MUST** have a unique key.
+> The evaluation context fields **MUST** have an unique key.
 
- The field key uniquely identifies any the field in the `evaluation context` and it should be unique accross all types to avoid any collision when marshelling the `evaluation context` by the provider.
+ The key uniquely identifies any the field in the `evaluation context` and it should be unique accross all types to avoid any collision when marshelling the `evaluation context` by the provider.
 
 ### Merging Context
 

--- a/specification/sections/03-evaluation-context.md
+++ b/specification/sections/03-evaluation-context.md
@@ -30,6 +30,8 @@ The targeting key uniquely identifies the subject (end-user, or client service) 
 
 > The evaluation context **MUST** support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | datetime | structure`.
 
+Each key should be unique.
+
 see: [structure](../types.md#structure), [datetime](../types.md#datetime)
 
 ### Merging Context

--- a/specification/sections/03-evaluation-context.md
+++ b/specification/sections/03-evaluation-context.md
@@ -36,7 +36,7 @@ see: [structure](../types.md#structure), [datetime](../types.md#datetime)
 
 > The evaluation context fields **MUST** have an unique key.
 
- The key uniquely identifies any the field in the `evaluation context` and it should be unique accross all types to avoid any collision when marshelling the `evaluation context` by the provider.
+ The key uniquely identifies a field in the `evaluation context` and it should be unique accross all types to avoid any collision when marshelling the `evaluation context` by the provider.
 
 ### Merging Context
 


### PR DESCRIPTION
Following the discussion [here](https://cloud-native.slack.com/archives/C0344AANLA1/p1659469589273419) and this [issue](https://github.com/open-feature/java-sdk/issues/40), I believe it is necessary to explicitly say that each key from the `EvaluationContext` should be unique.

