### PR TITLE
Remove context transformation, ref in provider hooks

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -178,13 +178,6 @@
             "children": []
         },
         {
-            "id": "Requirement 1.6.1",
-            "machine_id": "requirement_1_6_1",
-            "content": "The `client` SHOULD transform the `evaluation context` using the `provider's` `context transformer` function if one is defined, before passing the result of the transformation to the provider's flag resolution functions.",
-            "RFC 2119 keyword": "SHOULD",
-            "children": []
-        },
-        {
             "id": "Requirement 2.1",
             "machine_id": "requirement_2_1",
             "content": "The provider interface MUST define a `metadata` member or accessor, containing a `name` field or accessor of type string, which identifies the provider implementation.",

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -218,11 +218,3 @@ It's recommended to provide non-blocking mechanisms for flag evaluation, particu
 > The `evaluation options` structure's `hooks` field denotes an ordered collection of hooks that the client **MUST** execute for the respective flag evaluation, in addition to those already configured.
 
 See [hooks](./04-hooks.md) for details.
-
-#### Context Transformation
-
-##### Requirement 1.6.1
-
-> The `client` **SHOULD** transform the `evaluation context` using the `provider's` `context transformer` function if one is defined, before passing the result of the transformation to the provider's flag resolution functions.
-
-See [context transformation](./02-providers.md#context-transformation) for details.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -113,7 +113,7 @@ ResolutionDetails<MyStruct> resolveStructureValue(string flagKey, MyStruct defau
 
 #### Provider hooks
 
-A `provider hook` exposes a mechanism for `providers authors` to register [`hooks`](./04-hooks.md) to tap into various stages of the flag evaluation lifecycle. These hooks can be used to perform side effects and mutate the context for purposes of the provider. Provider hooks are not configured or controlled by the `application author`.
+A `provider hook` exposes a mechanism for `provider authors` to register [`hooks`](./04-hooks.md) to tap into various stages of the flag evaluation lifecycle. These hooks can be used to perform side effects and mutate the context for purposes of the provider. Provider hooks are not configured or controlled by the `application author`.
 
 ##### Requirement 2.10
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -113,7 +113,7 @@ ResolutionDetails<MyStruct> resolveStructureValue(string flagKey, MyStruct defau
 
 #### Provider hooks
 
-A `provider hook` exposes a mechanism for `providers` to register [`hooks`](./04-hooks.md) to tap into various stages of the flag evaluation lifecycle. As one example, feature flag management systems often need to transform the context structures the user provides.
+A `provider hook` exposes a mechanism for `providers authors` to register [`hooks`](./04-hooks.md) to tap into various stages of the flag evaluation lifecycle. These hooks can be used to perform side effects and mutate the context for purposes of the provider. Provider hooks are not configured or controlled by the `application author`.
 
 ##### Requirement 2.10
 


### PR DESCRIPTION
- remove entire `context transformation` section (has not been widely adopted)
- remove mention `context transformation` from provider hooks
- add a bit more context to provider hooks intro

See: https://github.com/open-feature/spec/pull/119#issuecomment-1209128006

cc @agentgonzo @justinabrahms @beeme1mr 