### PR TITLE
chore: add additional document statuses

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -35,7 +35,24 @@ An implementation is not compliant if it fails to satisfy one or more of the "MU
 
 ## Document Statuses
 
-| Status               | Explanation                   |
-| -------------------- | ----------------------------- |
-| No Explicit "Status" | Equivalent to Experimental.   |
-| Experimental         | Breaking changes are allowed. |
+Documents and subsections within the specification are marked with statuses indicating their stability level. Functionality described in the specification graduates through these statuses with increasing stability. Stability levels apply only to normative sections within the specification; editorial changes to examples and explanations are exempt from these constraints.
+
+Possible statuses are described below:
+
+### Experimental
+
+Specification documents that are marked as `Experimental` contain functionality under active development. Breaking changes are allowed and may be made without deprecation notices or warnings with minor version updates.
+
+### Hardening
+
+Documents marked as `Hardening` describe functionality with an emphasis on stabilizing existing requirements. Breaking changes require consensus by the [Technical Steering Committee](https://github.com/open-feature/community/blob/main/governance-charter.md#tsc-members) but may still be made with minor version updates.
+
+### Stable
+
+Sections marked as `Stable` do not allow breaking changes without a major version update.
+
+### Mixed
+
+Specification documents marked as `Mixed` contain subsections of varying statuses specified above.
+
+NOTE: No explicit status = `Experimental`

--- a/specification/README.md
+++ b/specification/README.md
@@ -46,7 +46,7 @@ Possible statuses are described below:
 
 Specification documents that are marked as `Experimental` contain functionality under active development. Breaking changes are allowed and may be made without deprecation notices or warnings with minor version updates. We recommend you use these features in experimental environments and not in production.
 
-Put simply: 
+Put simply:
 
 > We're testing these features out. Things could change anytime.
 
@@ -54,7 +54,7 @@ Put simply:
 
 Documents marked as `Hardening` describe functionality with an emphasis on stabilizing existing requirements. Breaking changes require consensus by the [Technical Steering Committee](https://github.com/open-feature/community/blob/main/governance-charter.md#tsc-members) but may still be made with minor version updates. These features are suitable for use in production environments. Feedback is encouraged.
 
-Put simply: 
+Put simply:
 
 > We believe these features are ready for production use, and hope for feedback.
 
@@ -62,7 +62,7 @@ Put simply:
 
 Sections marked as `Stable` do not allow breaking changes without a major version update. They can be used in production with a high degree of confidence.
 
-Put simply: 
+Put simply:
 
 > These features are stable and battle-hardened.
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -60,7 +60,7 @@ Put simply:
 
 ### Stable
 
-Sections marked as `Stable` do not allow breaking changes without a major version update.
+Sections marked as `Stable` do not allow breaking changes without a major version update. They can be used in production with a high degree of confidence.
 
 Put simply: 
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -35,21 +35,36 @@ An implementation is not compliant if it fails to satisfy one or more of the "MU
 
 ## Document Statuses
 
-Documents and subsections within the specification are marked with statuses indicating their stability level. Functionality described in the specification graduates through these statuses with increasing stability. Stability levels apply only to normative sections within the specification; editorial changes to examples and explanations are exempt from these constraints.
+Documents and subsections within the specification are marked with statuses indicating their stability level.
+Functionality described in the specification graduates through these statuses with increasing stability.
+Stability levels apply only to normative sections within the specification; editorial changes to examples and explanations are exempt from these constraints.
+It is the responsibility of the [Technical Steering Committee](https://github.com/open-feature/community/blob/main/governance-charter.md#tsc-members) to consider and approve the graduation of documents.
 
 Possible statuses are described below:
 
 ### Experimental
 
-Specification documents that are marked as `Experimental` contain functionality under active development. Breaking changes are allowed and may be made without deprecation notices or warnings with minor version updates.
+Specification documents that are marked as `Experimental` contain functionality under active development. Breaking changes are allowed and may be made without deprecation notices or warnings with minor version updates. We recommend you use these features in experimental environments and not in production.
+
+Put simply: 
+
+> We're testing these features out. Things could change anytime.
 
 ### Hardening
 
-Documents marked as `Hardening` describe functionality with an emphasis on stabilizing existing requirements. Breaking changes require consensus by the [Technical Steering Committee](https://github.com/open-feature/community/blob/main/governance-charter.md#tsc-members) but may still be made with minor version updates.
+Documents marked as `Hardening` describe functionality with an emphasis on stabilizing existing requirements. Breaking changes require consensus by the [Technical Steering Committee](https://github.com/open-feature/community/blob/main/governance-charter.md#tsc-members) but may still be made with minor version updates. These features are suitable for use in production environments. Feedback is encouraged.
+
+Put simply: 
+
+> We believe these features are ready for production use, and hope for feedback.
 
 ### Stable
 
 Sections marked as `Stable` do not allow breaking changes without a major version update.
+
+Put simply: 
+
+> These features are stable and battle-hardened.
 
 ### Mixed
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -35,7 +35,7 @@ An implementation is not compliant if it fails to satisfy one or more of the "MU
 
 ## Document Statuses
 
-Documents and subsections within the specification are marked with statuses indicating their stability level.
+Sections and subsections within the specification are marked with statuses indicating their stability level.
 Functionality described in the specification graduates through these statuses with increasing stability.
 Stability levels apply only to normative sections within the specification; editorial changes to examples and explanations are exempt from these constraints.
 It is the responsibility of the [Technical Steering Committee](https://github.com/open-feature/community/blob/main/governance-charter.md#tsc-members) to consider and approve the graduation of documents.
@@ -44,7 +44,7 @@ Possible statuses are described below:
 
 ### Experimental
 
-Specification documents that are marked as `Experimental` contain functionality under active development. Breaking changes are allowed and may be made without deprecation notices or warnings with minor version updates. We recommend you use these features in experimental environments and not in production.
+Specification sections that are marked as `Experimental` contain functionality under active development. Breaking changes are allowed and may be made without deprecation notices or warnings with minor version updates. We recommend you use these features in experimental environments and not in production.
 
 Put simply:
 
@@ -52,7 +52,7 @@ Put simply:
 
 ### Hardening
 
-Documents marked as `Hardening` describe functionality with an emphasis on stabilizing existing requirements. Breaking changes require consensus by the [Technical Steering Committee](https://github.com/open-feature/community/blob/main/governance-charter.md#tsc-members) but may still be made with minor version updates. These features are suitable for use in production environments. Feedback is encouraged.
+Sections marked as `Hardening` describe functionality with an emphasis on stabilizing existing requirements. Breaking changes require consensus by the [Technical Steering Committee](https://github.com/open-feature/community/blob/main/governance-charter.md#tsc-members) but may still be made with minor version updates. These features are suitable for use in production environments. Feedback is encouraged.
 
 Put simply:
 
@@ -65,9 +65,5 @@ Sections marked as `Stable` do not allow breaking changes without a major versio
 Put simply:
 
 > These features are stable and battle-hardened.
-
-### Mixed
-
-Specification documents marked as `Mixed` contain subsections of varying statuses specified above.
 
 NOTE: No explicit status = `Experimental`


### PR DESCRIPTION
Adds document statuses explaining stability of various spec documents and sub-sections.

This is important as we move toward's 1.0 SDK releases and a stable spec.