### PR TITLE
chore: clarify timezone requirement

### DIFF
--- a/specification/types.md
+++ b/specification/types.md
@@ -28,7 +28,7 @@ Structured data, presented however is idiomatic in the implementation language, 
 
 ### Datetime
 
-A language primitive for representing a date and time, including timezone information.
+A language primitive for representing a date and time, optionally including timezone information.
 
 ### Evaluation Details
 

--- a/specification/types.md
+++ b/specification/types.md
@@ -28,7 +28,7 @@ Structured data, presented however is idiomatic in the implementation language, 
 
 ### Datetime
 
-A language primitive for representing a date and time, optionally including timezone information.
+A language primitive for representing a date and time, optionally including timezone information. If no timezone is specified, the date and time will be treated as UTC.
 
 ### Evaluation Details
 


### PR DESCRIPTION
A small change to make the timezone info on the `Datetime` type optional. Some SDKs already do not include timezone info.

Since it's loosening this definition, this is non-breaking.