### PR TITLE
docs: include STATIC and CACHED in provider reasons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 __pycache__
+.idea

--- a/specification.json
+++ b/specification.json
@@ -230,7 +230,7 @@
         {
             "id": "Requirement 2.2.5",
             "machine_id": "requirement_2_2_5",
-            "content": "The `provider` SHOULD populate the `resolution details` structure's `reason` field with `\"DEFAULT\",` `\"TARGETING_MATCH\"`, `\"SPLIT\"`, `\"DISABLED\"`, `\"UNKNOWN\"`, `\"ERROR\"` or some other string indicating the semantic reason for the returned flag value.",
+            "content": "The `provider` SHOULD populate the `resolution details` structure's `reason` field with `\"STATIC\"`, `\"DEFAULT\",` `\"TARGETING_MATCH\"`, `\"SPLIT\"`, `\"CACHED\"`, `\"DISABLED\"`, `\"UNKNOWN\"`, `\"ERROR\"` or some other string indicating the semantic reason for the returned flag value.",
             "RFC 2119 keyword": "SHOULD",
             "children": []
         },

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -77,7 +77,7 @@ The value of the variant field might only be meaningful in the context of the fl
 
 ##### Requirement 2.2.5
 
-> The `provider` **SHOULD** populate the `resolution details` structure's `reason` field with `"DEFAULT",` `"TARGETING_MATCH"`, `"SPLIT"`, `"DISABLED"`, `"UNKNOWN"`, `"ERROR"` or some other string indicating the semantic reason for the returned flag value.
+> The `provider` **SHOULD** populate the `resolution details` structure's `reason` field with `"STATIC"`, `"DEFAULT",` `"TARGETING_MATCH"`, `"SPLIT"`, `"CACHED"`, `"DISABLED"`, `"UNKNOWN"`, `"ERROR"` or some other string indicating the semantic reason for the returned flag value.
 
 As indicated in the definition of the [`resolution details`](../types.md#resolution-details) structure, the `reason` should be a string. This allows providers to reflect accurately why a flag was resolved to a particular value.
 

--- a/specification/types.md
+++ b/specification/types.md
@@ -54,10 +54,12 @@ A structure which contains a subset of the fields defined in the `evaluation det
 A set of pre-defined reasons is enumerated below:
 
 | Reason          | Explanation                                                                                           |
-| --------------- | ----------------------------------------------------------------------------------------------------- |
-| DEFAULT         | The resolved value was configured statically, or otherwise fell back to a pre-configured value.       |
+| --------------- |-------------------------------------------------------------------------------------------------------|
+| STATIC          | The resolved value is static (no dynamic evaluation).                                                 |
+| DEFAULT         | The resolved value fell back to a pre-configured value (dynamic evaluation yielded no result).        |
 | TARGETING_MATCH | The resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting. |
 | SPLIT           | The resolved value was the result of pseudorandom assignment.                                         |
+| CACHED          | The resolved value was retrieved from cache.                                                          |
 | DISABLED        | The resolved value was the result of the flag being disabled in the management system.                |
 | UNKNOWN         | The reason for the resolved value could not be determined.                                            |
 | ERROR           | The resolved value was the result of an error.                                                        |

--- a/specification/types.md
+++ b/specification/types.md
@@ -56,7 +56,7 @@ A set of pre-defined reasons is enumerated below:
 | Reason          | Explanation                                                                                           |
 | --------------- |-------------------------------------------------------------------------------------------------------|
 | STATIC          | The resolved value is static (no dynamic evaluation).                                                 |
-| DEFAULT         | The resolved value fell back to a pre-configured value (dynamic evaluation yielded no result).        |
+| DEFAULT         | The resolved value fell back to a pre-configured value (no dynamic evaluation occurred or dynamic evaluation yielded no result).        |
 | TARGETING_MATCH | The resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting. |
 | SPLIT           | The resolved value was the result of pseudorandom assignment.                                         |
 | CACHED          | The resolved value was retrieved from cache.                                                          |


### PR DESCRIPTION
## This PR

Revives the `STATIC` reason in order to determine which values are cacheable.
Introduces the CACHED reason in order to report to the client that the value has been retrieved from cache.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #165 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

