### PR TITLE
Pete/provider metadata

### DIFF
--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -187,6 +187,18 @@ FlagEvaluationDetails<MyStruct> myStructDetails = client.getObjectDetails<MyStru
 
 > In cases of normal execution, the `evaluation details` structure's `reason` field **MUST** contain the value of the `reason` field in the `flag resolution` structure returned by the configured `provider`, if the field is set.
 
+##### Requirement 1.4.X
+
+> If the `flag metadata` field in the `flag resolution` structure returned by the configured `provider` is set, the `evaluation details` structure's `flag metadata` field **MUST** contain that value. Otherwise, it **MUST** contain an empty record.
+
+#### Condition X.
+
+> The implementation language supports a mechanism for marking data as immutable.
+
+##### Conditional Requirement X.
+
+> Condition: `Flag metadata` **MUST** be immutable.
+  
 ##### Requirement 1.4.7
 
 > In cases of abnormal execution, the `evaluation details` structure's `error code` field **MUST** contain an `error code`.

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -187,47 +187,47 @@ FlagEvaluationDetails<MyStruct> myStructDetails = client.getObjectDetails<MyStru
 
 > In cases of normal execution, the `evaluation details` structure's `reason` field **MUST** contain the value of the `reason` field in the `flag resolution` structure returned by the configured `provider`, if the field is set.
 
-##### Requirement 1.4.X
+##### Requirement 1.4.7
 
 > If the `flag metadata` field in the `flag resolution` structure returned by the configured `provider` is set, the `evaluation details` structure's `flag metadata` field **MUST** contain that value. Otherwise, it **MUST** contain an empty record.
 
-#### Condition X.
+##### Condition 1.4.8
 
 > The implementation language supports a mechanism for marking data as immutable.
 
-##### Conditional Requirement X.
+###### Conditional Requirement 1.4.8.1
 
 > Condition: `Flag metadata` **MUST** be immutable.
   
-##### Requirement 1.4.7
+##### Requirement 1.4.9
 
 > In cases of abnormal execution, the `evaluation details` structure's `error code` field **MUST** contain an `error code`.
 
 See [error code](../types.md#error-code) for details.
 
-##### Requirement 1.4.8
+##### Requirement 1.4.10
 
 > In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field in the `evaluation details` **SHOULD** indicate an error.
 
-##### Requirement 1.4.9
+##### Requirement 1.4.11
 
 > Methods, functions, or operations on the client **MUST NOT** throw exceptions, or otherwise abnormally terminate. Flag evaluation calls must always return the `default value` in the event of abnormal execution. Exceptions include functions or methods for the purposes for configuration or setup.
 
 Configuration code includes code to set the provider, instantiate providers, and configure the global API object.
 
-##### Requirement 1.4.10
+##### Requirement 1.4.12
 
 > In the case of abnormal execution, the client **SHOULD** log an informative error message.
 
 Implementations may define a standard logging interface that can be supplied as an optional argument to the client creation function, which may wrap standard logging functionality of the implementation language.
 
-##### Requirement 1.4.11
+##### Requirement 1.4.13
 
 > The `client` **SHOULD** provide asynchronous or non-blocking mechanisms for flag evaluation.
 
 It's recommended to provide non-blocking mechanisms for flag evaluation, particularly in languages or environments wherein there's a single thread of execution.
 
-##### Requirement 1.4.12
+##### Requirement 1.4.14
 
 > In cases of abnormal execution, the `evaluation details` structure's `error message` field **MAY** contain a string containing additional details about the nature of the error.
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -81,17 +81,17 @@ The value of the variant field might only be meaningful in the context of the fl
 
 As indicated in the definition of the [`resolution details`](../types.md#resolution-details) structure, the `reason` should be a string. This allows providers to reflect accurately why a flag was resolved to a particular value.
 
-##### Requirement 2.2.X
+##### Requirement 2.2.6
 
 > The `provider` **SHOULD** populate the `resolution details` structure's `flag metadata` field. 
 
 > `flag metadata` **MUST** be a structure supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean | string | number`.
 
-##### Requirement 2.2.6
+##### Requirement 2.2.7
 
 > In cases of normal execution, the `provider` **MUST NOT** populate the `resolution details` structure's `error code` field, or otherwise must populate it with a null or falsy value.
 
-##### Requirement 2.2.7
+##### Requirement 2.2.8
 
 > In cases of abnormal execution, the `provider` **MUST** indicate an error using the idioms of the implementation language, with an associated `error code` and optional associated `error message`.
 
@@ -104,11 +104,11 @@ See [error code](../types.md#error-code) for details.
 throw new ProviderError(ErrorCode.INVALID_CONTEXT, "The 'foo' attribute must be a string.");
 ```
 
-##### Condition 2.2.8
+##### Condition 2.2.9
 
 > The implementation language supports generics (or an equivalent feature).
 
-###### Conditional Requirement 2.2.8.1
+###### Conditional Requirement 2.2.9.1
 
 > The `resolution details` structure **SHOULD** accept a generic argument (or use an equivalent language feature) which indicates the type of the wrapped `value` field.
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -81,6 +81,12 @@ The value of the variant field might only be meaningful in the context of the fl
 
 As indicated in the definition of the [`resolution details`](../types.md#resolution-details) structure, the `reason` should be a string. This allows providers to reflect accurately why a flag was resolved to a particular value.
 
+##### Requirement 2.2.X
+
+> The `provider` **SHOULD** populate the `resolution details` structure's `flag metadata` field. 
+
+> `flag metadata` **MUST** be a structure supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean | string | number`.
+
 ##### Requirement 2.2.6
 
 > In cases of normal execution, the `provider` **MUST NOT** populate the `resolution details` structure's `error code` field, or otherwise must populate it with a null or falsy value.

--- a/specification/types.md
+++ b/specification/types.md
@@ -40,6 +40,7 @@ A structure representing the result of the [flag evaluation process](./glossary.
 - error message (string, optional)
 - reason (string, optional)
 - variant (string, optional)
+- flag metadata (Record<string,boolean | string | number>)
 
 ### Resolution Details
 
@@ -50,6 +51,7 @@ A structure which contains a subset of the fields defined in the `evaluation det
 - error message (string, optional)
 - reason (string, optional)
 - variant (string, optional)
+- flag metadata (Record<string,boolean | string | number>, optional)
 
 A set of pre-defined reasons is enumerated below:
 


### PR DESCRIPTION
- add a `flag metadata` field to Evaluation Details and Resolution Details
- ask the provider to provide it in Resolution Details
- require the SDK to expose it to Evaluation Details

(co-authored with @justinabrahms)