### PR TITLE
fix: links and link checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ parse: _check_python
 lint: node_modules
 	@python ./tools/specification_parser/lint_json_output.py specification.json
 	./node_modules/.bin/markdownlint --ignore node_modules/ --ignore tools/ **/*.md
-	./node_modules/.bin/markdown-link-check -c .markdown-link-check-config.json README.md specification/*.md
+	./node_modules/.bin/markdown-link-check -c .markdown-link-check-config.json README.md specification/*.md specification/**/*.md
 
 fix: node_modules
 	prettier -w **/*.md

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -92,7 +92,7 @@ A source-of-truth for flag values and rules. Flag management systems may include
 
 ### Provider
 
-An SDK-compliant implementation which resolves flag values from a particular flag management system, allowing the use of the [Evaluation API](./sections/01-flag-evaluation.md#flag-evaluation) as an abstraction for the system in question.
+An SDK-compliant implementation which resolves flag values from a particular flag management system, allowing the use of the [Evaluation API](./sections/01-flag-evaluation.md#13-flag-evaluation) as an abstraction for the system in question.
 
 ### Integration
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -39,7 +39,7 @@ provider.getMetadata().getName(); // "my-custom-provider"
 resolveBooleanValue(flagKey, defaultValue, context);
 ```
 
-see: [flag resolution structure](../types.md#resolution-details), [flag value resolution](../glossary.md#flag-value-resolution)
+see: [flag resolution structure](../types.md#resolution-details), [flag value resolution](../glossary.md#resolving-flag-values)
 
 ##### Condition 2.2.2
 

--- a/specification/types.md
+++ b/specification/types.md
@@ -32,7 +32,7 @@ A language primitive for representing a date and time, optionally including time
 
 ### Evaluation Details
 
-A structure representing the result of the [flag evaluation process](./glossary.md#evaluating-flag-values), and made available in the [detailed flag resolution functions](./sections/01-flag-evaluation.md#detailed-flag-evaluation), containing the following fields:
+A structure representing the result of the [flag evaluation process](./glossary.md#evaluating-flag-values), and made available in the [detailed flag resolution functions](./sections/01-flag-evaluation.md#14-detailed-flag-evaluation), containing the following fields:
 
 - flag key (string, required)
 - value (boolean | string | number | structure, required)


### PR DESCRIPTION
We we're missing some checks for `markdown-link-check`.

Unfortunately, there's some bugs in it that don't check anchors in other docs, so until that's fixed we might still occasionally get broken links. I've manually fixed all link issues with this PR though (I hope).

There doesn't appear to be many alternatives, so we may want to consider fixing [this bug](https://github.com/tcort/markdown-link-check/issues/212).