### PR TITLE
feat: STALE state, run handlers for current state immediately, provider name

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -31,7 +31,7 @@
         {
             "id": "Requirement 1.1.3",
             "machine_id": "requirement_1_1_3",
-            "content": "The `API` MUST provide a function to bind a given `provider` to a client `name`. If the client-name already has a bound provider, it is overwritten with the new mapping.",
+            "content": "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -31,7 +31,7 @@
         {
             "id": "Requirement 1.1.3",
             "machine_id": "requirement_1_1_3",
-            "content": "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.",
+            "content": "The `API` MUST provide a function to bind a given `provider` to a client `name`. If the client-name already has a bound provider, it is overwritten with the new mapping.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -796,7 +796,7 @@
         {
             "id": "Requirement 5.2.3",
             "machine_id": "requirement_5_2_3",
-            "content": "The `event details` MUST contain the `client name` associated with the event.",
+            "content": "The `event details` MUST contain the `provider name` associated with the event.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -845,7 +845,7 @@
         {
             "id": "Requirement 5.3.3",
             "machine_id": "requirement_5_3_3",
-            "content": "`PROVIDER_READY` handlers attached after the provider is already in a ready state MUST run immediately.",
+            "content": "Client `PROVIDER_READY` handlers attached after the provider is in a ready state MUST run immediately.",
             "RFC 2119 keyword": "MUST",
             "children": []
         }

--- a/specification.json
+++ b/specification.json
@@ -845,7 +845,7 @@
         {
             "id": "Requirement 5.3.3",
             "machine_id": "requirement_5_3_3",
-            "content": "`PROVIDER_READY` handlers attached after the provider is in a ready state MUST run immediately.",
+            "content": "Handlers attached after the provider is already in the associated state, MUST run immediately.",
             "RFC 2119 keyword": "MUST",
             "children": []
         }

--- a/specification.json
+++ b/specification.json
@@ -845,7 +845,7 @@
         {
             "id": "Requirement 5.3.3",
             "machine_id": "requirement_5_3_3",
-            "content": "Client `PROVIDER_READY` handlers attached after the provider is in a ready state MUST run immediately.",
+            "content": "`PROVIDER_READY` handlers attached after the provider is in a ready state MUST run immediately.",
             "RFC 2119 keyword": "MUST",
             "children": []
         }

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -98,7 +98,7 @@ See [provider](./02-providers.md) for details.
 
 ```java
 // example client creation and retrieval
-OpenFeature.getClient(name: "my-named-client");
+OpenFeature.getClient("my-named-client");
 ```
 
 The name is a logical identifier for the client which may be associated with a particular provider by the application integrator.

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -101,7 +101,7 @@ See [provider](./02-providers.md) for details.
 OpenFeature.getClient(name: "my-named-client");
 ```
 
-The name is a logical identifier for the client which may be associated with a particular provider.
+The name is a logical identifier for the client which may be associated with a particular provider by the application integrator.
 If a client name is not bound to a particular provider, the client is associated with the default provider.
 
 See [setting a provider](#setting-a-provider) for details.

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -56,7 +56,7 @@ see: [shutdown](./02-providers.md#25-shutdown), [setting a provider](#setting-a-
 
 #### Requirement 1.1.3
 
-> The `API` **MUST** provide a function to bind a given `provider` to a client `name`. If the client-name already has a bound provider, it is overwritten with the new mapping.
+> The `API` **MUST** provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.
 
 ```java
 OpenFeature.setProvider("client-name", new MyProvider());

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -31,9 +31,9 @@ It's important that multiple instances of the `API` not be active, so that state
 OpenFeature.setProvider(new MyProvider());
 ```
 
-This provider is used if there is not a more specific client name binding. (see later requirements).
+This provider is used if a client is not bound to a specific provider through its name.
 
-See [provider](./02-providers.md) for details.
+See [provider](./02-providers.md), [creating clients](#creating-clients).
 
 #### Requirement 1.1.2.2
 
@@ -56,11 +56,15 @@ see: [shutdown](./02-providers.md#25-shutdown), [setting a provider](#setting-a-
 
 #### Requirement 1.1.3
 
-> The `API` **MUST** provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.
+> The `API` **MUST** provide a function to bind a given `provider` to a client `name`. If the client-name already has a bound provider, it is overwritten with the new mapping.
 
 ```java
 OpenFeature.setProvider("client-name", new MyProvider());
 ```
+
+Named clients can be associated with a particular provider by supplying a matching name when the provider is set.
+
+See [creating clients](#creating-clients).
 
 #### Requirement 1.1.4
 
@@ -84,20 +88,23 @@ OpenFeature.getProviderMetadata();
 
 See [provider](./02-providers.md) for details.
 
+### Creating clients
+
 #### Requirement 1.1.6
 
 > The `API` **MUST** provide a function for creating a `client` which accepts the following options:
 >
 > - name (optional): A logical string identifier for the client.
 
-```typescript
+```java
 // example client creation and retrieval
-OpenFeature.getClient({
-  name: "my-openfeature-client",
-});
+OpenFeature.getClient(name: "my-named-client");
 ```
 
-The name is a logical identifier for the client.
+The name is a logical identifier for the client which may be associated with a particular provider.
+If a client name is not bound to a particular provider, the client is associated with the default provider.
+
+See [setting a provider](#setting-a-provider) for details.
 
 #### Requirement 1.1.7
 

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -136,7 +136,7 @@ See [provider initialization](./02-providers.md#24-initialization) and [setting 
 
 #### Requirement 5.3.3
 
-> Client `PROVIDER_READY` handlers attached after the provider is in a ready state **MUST** run immediately.
+> `PROVIDER_READY` handlers attached after the provider is in a ready state **MUST** run immediately.
 
 _Application authors_ may attach readiness handlers to be confident that system is ready to evaluate flags.
 If such handlers are attached after the provider underlying the client has already been initialized, they should run immediately.

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -140,6 +140,5 @@ See [provider initialization](./02-providers.md#24-initialization) and [setting 
 
 _Application authors_ may attach readiness handlers to be confident that system is ready to evaluate flags.
 If such handlers are attached after the provider underlying the client has already been initialized, they should run immediately.
-API (global) handlers have no such requirement, as they are potentially bound to multiple providers and are used primarily for diagnostic purposes.
 
 See [provider initialization](./02-providers.md#24-initialization), [setting a provider](./01-flag-evaluation.md#setting-a-provider).

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -1,5 +1,5 @@
 ---
-title: Events Extensions
+title: Events
 description: Specification defining event semantics
 toc_max_heading_level: 4
 ---
@@ -80,10 +80,12 @@ see: [provider events](#51-provider-events), [`provider event types`](../types.m
 
 #### Requirement 5.2.3
 
-> The `event details` **MUST** contain the `client name` associated with the event.
+> The `event details` **MUST** contain the `provider name` associated with the event.
 
-The `client name` indicates the client/provider pair with which the event is associated.
-This is especially relevant for event handlers which are attached to the `API`, not a particular client.
+The `provider name` indicates the provider from which the event originated.
+This is especially relevant for global event handlers used for general monitoring, such as alerting on provider errors. 
+
+See [setting a provider](./01-flag-evaluation.md#setting-a-provider), [creating clients](./01-flag-evaluation.md#creating-clients). 
 
 #### Requirement 5.2.4
 
@@ -99,7 +101,7 @@ see: [`event details`](../types.md#event-details)
 
 > Event handlers **MUST** persist across `provider` changes.
 
-If a provider is changed, existing event handlers will still fire.
+If the underlying provider is changed, existing client and API event handlers will still fire.
 This means that the order of provider configuration and event handler addition is independent.
 
 #### Requirement 5.2.7
@@ -134,6 +136,10 @@ See [provider initialization](./02-providers.md#24-initialization) and [setting 
 
 #### Requirement 5.3.3
 
-> `PROVIDER_READY` handlers attached after the provider is already in a ready state **MUST** run immediately.
+> Client `PROVIDER_READY` handlers attached after the provider is in a ready state **MUST** run immediately.
 
-See [provider initialization](./02-providers.md#24-initialization) and [setting a provider](./01-flag-evaluation.md#setting-a-provider).
+_Application authors_ may attach readiness handlers to be confident that system is ready to evaluate flags.
+If such handlers are attached after the provider underlying the client has already been initialized, they should run immediately.
+API (global) handlers have no such requirement, as they are potentially bound to multiple providers and are used primarily for diagnostic purposes.
+
+See [provider initialization](./02-providers.md#24-initialization), [setting a provider](./01-flag-evaluation.md#setting-a-provider).

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -136,9 +136,11 @@ See [provider initialization](./02-providers.md#24-initialization) and [setting 
 
 #### Requirement 5.3.3
 
-> `PROVIDER_READY` handlers attached after the provider is in a ready state **MUST** run immediately.
+> Handlers attached after the provider is already in the associated state, **MUST** run immediately.
 
-_Application authors_ may attach readiness handlers to be confident that system is ready to evaluate flags.
+Handlers may be attached at any point in the application lifecycle.
+Handlers should run immediately if the provider is already in the associated state.
+For instance, _application authors_ may attach readiness handlers to be confident that system is ready to evaluate flags.
 If such handlers are attached after the provider underlying the client has already been initialized, they should run immediately.
 
 See [provider initialization](./02-providers.md#24-initialization), [setting a provider](./01-flag-evaluation.md#setting-a-provider).

--- a/specification/types.md
+++ b/specification/types.md
@@ -99,11 +99,12 @@ This structure is populated by a provider for use by an [Application Author](./g
 
 An enumeration of possible provider states.
 
-| Status    | Explanation                                                                     |
-| --------- | ------------------------------------------------------------------------------- |
-| NOT_READY | The provider has not been initialized.                                          |
-| READY     | The provider has been initialized, and is able to reliably resolve flag values. |
-| ERROR     | The provider is initialized but is not able to reliably resolve flag values.    |
+| Status    | Explanation                                                                                         |
+| --------- | --------------------------------------------------------------------------------------------------- |
+| NOT_READY | The provider has not been initialized.                                                              |
+| READY     | The provider has been initialized, and is able to reliably resolve flag values.                     |
+| ERROR     | The provider is initialized but is not able to reliably resolve flag values.                        |
+| STALE     | The provider's cached state is not longer valid and may not be up-to-date with the source of truth. |
 
 ### Provider Event Details
 

--- a/specification/types.md
+++ b/specification/types.md
@@ -104,7 +104,7 @@ An enumeration of possible provider states.
 | NOT_READY | The provider has not been initialized.                                                              |
 | READY     | The provider has been initialized, and is able to reliably resolve flag values.                     |
 | ERROR     | The provider is initialized but is not able to reliably resolve flag values.                        |
-| STALE     | The provider's cached state is not longer valid and may not be up-to-date with the source of truth. |
+| STALE     | The provider's cached state is no longer valid and may not be up-to-date with the source of truth.  |
 
 ### Provider Event Details
 
@@ -137,7 +137,7 @@ An enumeration of provider events.
 | PROVIDER_READY                 | The provider is ready to perform flag evaluations.                                                  |
 | PROVIDER_ERROR                 | The provider signalled an error.                                                                    |
 | PROVIDER_CONFIGURATION_CHANGED | A change was made to the backend flag configuration.                                                |
-| PROVIDER_STALE                 | The provider's cached state is not longer valid and may not be up-to-date with the source of truth. |
+| PROVIDER_STALE                 | The provider's cached state is no longer valid and may not be up-to-date with the source of truth.  |
 
 ### Handler Functions
 


### PR DESCRIPTION
* Adds additional clarity regarding provider/client name mapping, as well as intent
* Replaces client-name for provider-name in events-details
* adds "STALE" state
* handlers for ANY state run immediately if provider is in that state

The only functional changes here are small ones related to events, and a new provider state, so particularly interested in @Kavindu-Dodan and @lukas-reining 's opinions on this one.

Relates to https://github.com/open-feature/spec/pull/200, which depends on `STALE` state.