### PR TITLE
feat: emit events on context change (client-only)

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -891,6 +891,27 @@
             "content": "Handlers attached after the provider is already in the associated state, MUST run immediately.",
             "RFC 2119 keyword": "MUST",
             "children": []
+        },
+        {
+            "id": "Requirement 5.3.4",
+            "machine_id": "requirement_5_3_4",
+            "content": "When the provider's `on context changed` is called, `PROVIDER_STALE` handlers MUST run.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Requirement 5.3.5",
+            "machine_id": "requirement_5_3_5",
+            "content": "If the provider's `on context changed` function terminates successfully, `PROVIDER_READY` handlers MUST run.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Requirement 5.3.6",
+            "machine_id": "requirement_5_3_6",
+            "content": "If the provider's `on context changed` function terminates abnormally, `PROVIDER_ERROR` handlers MUST run.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
         }
     ]
 }

--- a/specification.json
+++ b/specification.json
@@ -893,25 +893,33 @@
             "children": []
         },
         {
-            "id": "Requirement 5.3.4",
-            "machine_id": "requirement_5_3_4",
-            "content": "When the provider's `on context changed` is called, `PROVIDER_STALE` handlers MUST run.",
-            "RFC 2119 keyword": "MUST",
-            "children": []
-        },
-        {
-            "id": "Requirement 5.3.5",
-            "machine_id": "requirement_5_3_5",
-            "content": "If the provider's `on context changed` function terminates successfully, `PROVIDER_READY` handlers MUST run.",
-            "RFC 2119 keyword": "MUST",
-            "children": []
-        },
-        {
-            "id": "Requirement 5.3.6",
-            "machine_id": "requirement_5_3_6",
-            "content": "If the provider's `on context changed` function terminates abnormally, `PROVIDER_ERROR` handlers MUST run.",
-            "RFC 2119 keyword": "MUST",
-            "children": []
+            "id": "Condition 5.3.4",
+            "machine_id": "condition_5_3_4",
+            "content": "The implementation uses the static-context paradigm.",
+            "RFC 2119 keyword": null,
+            "children": [
+                {
+                    "id": "Conditional Requirement 5.3.4.1",
+                    "machine_id": "conditional_requirement_5_3_4_1",
+                    "content": "When the provider's `on context changed` is called, the provider MAY emit the `PROVIDER_STALE` event, and transition to the `STALE` state.",
+                    "RFC 2119 keyword": "MAY",
+                    "children": []
+                },
+                {
+                    "id": "Conditional Requirement 5.3.4.2",
+                    "machine_id": "conditional_requirement_5_3_4_2",
+                    "content": "If the provider's `on context changed` function terminates normally, associated `PROVIDER_CONTEXT_CHANGED` handlers MUST run.",
+                    "RFC 2119 keyword": "MUST",
+                    "children": []
+                },
+                {
+                    "id": "Conditional Requirement 5.3.4.3",
+                    "machine_id": "conditional_requirement_5_3_4_3",
+                    "content": "If the provider's `on context changed` function terminates abnormally, associated `PROVIDER_ERROR` handlers MUST run.",
+                    "RFC 2119 keyword": "MUST",
+                    "children": []
+                }
+            ]
         }
     ]
 }

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -158,8 +158,7 @@ title: Provider context reconciliation
 stateDiagram-v2
     direction TB
     READY --> READY:emit(PROVIDER_CONTEXT_CHANGED)
-    READY --> ERROR
-    ERROR --> READY
+    ERROR --> READY:emit(PROVIDER_READY)
     READY --> STALE:emit(PROVIDER_STALE)
     STALE --> READY:emit(PROVIDER_CONTEXT_CHANGED)
     STALE --> ERROR:emit(PROVIDER_ERROR)

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -149,6 +149,7 @@ See [provider initialization](./02-providers.md#24-initialization), [setting a p
 
 Providers built to conform to the static context paradigm feature an additional `PROVIDER_CONTEXT_CHANGED` event, which is used to signal that the global context has been changed, and flags should be re-evaluated.
 This can be particularly useful for triggering UI repaints in multiple components when one component updates the [evaluation context](./03-evaluation-context.md).
+SDK implementations automatically fire the the `PROVIDER_CONTEXT_CHANGED` events if the `on context changed` handler terminates normally (and `PROVIDER_ERROR` events otherwise).
 Optionally, some providers may transition to a the `STALE` state while their associated context is waiting to be reconciled, since this may involve asynchronous operations such as network calls.
 
 ```mermaid

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -150,7 +150,7 @@ See [provider initialization](./02-providers.md#24-initialization), [setting a p
 Providers built to conform to the static context paradigm feature an additional `PROVIDER_CONTEXT_CHANGED` event, which is used to signal that the global context has been changed, and flags should be re-evaluated.
 This can be particularly useful for triggering UI repaints in multiple components when one component updates the [evaluation context](./03-evaluation-context.md).
 SDK implementations automatically fire the the `PROVIDER_CONTEXT_CHANGED` events if the `on context changed` handler terminates normally (and `PROVIDER_ERROR` events otherwise).
-Optionally, some providers may transition to a the `STALE` state while their associated context is waiting to be reconciled, since this may involve asynchronous operations such as network calls.
+Optionally, some providers may transition to the `STALE` state while their associated context is waiting to be reconciled, since this may involve asynchronous operations such as network calls.
 
 ```mermaid
 ---

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -144,3 +144,21 @@ For instance, _application authors_ may attach readiness handlers to be confiden
 If such handlers are attached after the provider underlying the client has already been initialized, they should run immediately.
 
 See [provider initialization](./02-providers.md#24-initialization), [setting a provider](./01-flag-evaluation.md#setting-a-provider).
+
+#### Requirement 5.3.4
+
+> When the provider's `on context changed` is called, `PROVIDER_STALE` handlers **MUST** run.
+
+See: [provider events](#51-provider-events), [`provider event types`](../types.md#provider-events)
+
+#### Requirement 5.3.5
+
+> If the provider's `on context changed` function terminates successfully, `PROVIDER_READY` handlers **MUST** run.
+
+See: [provider events](#51-provider-events), [`provider event types`](../types.md#provider-events)
+
+#### Requirement 5.3.6
+
+> If the provider's `on context changed` function terminates abnormally, `PROVIDER_ERROR` handlers **MUST** run.
+
+See: [provider events](#51-provider-events), [`provider event types`](../types.md#provider-events)

--- a/specification/types.md
+++ b/specification/types.md
@@ -139,12 +139,15 @@ It supports definition of arbitrary properties, with keys of type `string`, and 
 
 An enumeration of provider events.
 
-| Event                          | Explanation                                                                                         |
-| ------------------------------ | --------------------------------------------------------------------------------------------------- |
-| PROVIDER_READY                 | The provider is ready to perform flag evaluations.                                                  |
-| PROVIDER_ERROR                 | The provider signalled an error.                                                                    |
-| PROVIDER_CONFIGURATION_CHANGED | A change was made to the backend flag configuration.                                                |
-| PROVIDER_STALE                 | The provider's cached state is no longer valid and may not be up-to-date with the source of truth.  |
+| Event                          | Explanation                                                                                                  |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| PROVIDER_READY                 | The provider is ready to perform flag evaluations.                                                           |
+| PROVIDER_ERROR                 | The provider signalled an error.                                                                             |
+| PROVIDER_CONFIGURATION_CHANGED | A change was made to the backend flag configuration.                                                         |
+| PROVIDER_STALE                 | The provider's cached state is no longer valid and may not be up-to-date with the source of truth.           |
+| PROVIDER_CONTEXT_CHANGED*      | The context associated with the provider has changed, and the provider has reconciled it's associated state. |
+
+\* [static context (client-side) paradigm](./glossary.md#static-context-paradigm) only
 
 ### Handler Functions
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

This PR adds points to specify the behaviour of on context changed with respect to eventing.

- (optionally) emit `PROVIDER_STALE` when on context changed is executed with mismatching contexts
- emitting `PROVIDER_CONTEXT_CHANGED` when on context changed successfully terminates
- emitting `PROVIDER_ERROR` when on context changed terminates abnormally
