### PR TITLE
feat: blocking setProvider

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -64,6 +64,13 @@
             "children": []
         },
         {
+            "id": "Requirement 1.1.8",
+            "machine_id": "requirement_1_1_8",
+            "content": "The `API` SHOULD provide functions to set a provider and wait for the `initialize` function to return or throw.",
+            "RFC 2119 keyword": "SHOULD",
+            "children": []
+        },
+        {
             "id": "Requirement 1.2.1",
             "machine_id": "requirement_1_2_1",
             "content": "The client MUST provide a method to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.",

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -109,7 +109,7 @@ Clients may be created in critical code paths, and even per-request in server-si
 
 > The `API` **SHOULD** provide functions to set a provider and wait for the `initialize` function to return or throw.
 
-The `API` will ensure that the provider initialization is ready or in error before being able to initializing the client.
+The `API` will ensure that the provider is ready or in error before being able to initializing the client.
 
 ```typescript
 // default client

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -111,14 +111,14 @@ Clients may be created in critical code paths, and even per-request in server-si
 
 This function not only sets the provider, but ensures that the provider is ready (or in error) before returning or settling.
 
-```typescript
+```java
 // default client
-await Openfeature.setProviderAndWait(myprovider);
-const client = Openfeature.getClient();
+OpenFeatureAPI.getInstance().setProviderAndWait(myprovider);
+Client client = OpenFeatureAPI.getInstance().getClient();
 
 // named client
-await Openfeature.setProviderAndWait('client-name', myprovider);
-const client = Openfeature.getClient('client-name');
+OpenFeatureAPI.getInstance().setProviderAndWait('client-name', myprovider);
+Client client = OpenFeatureAPI.getInstance().getClient('client-name');
 ```
 
 Though it's possible to use [events](./05-events.md) to await provider readiness, such functions can make things simpler for `application authors` and `integrators`.

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -109,7 +109,7 @@ Clients may be created in critical code paths, and even per-request in server-si
 
 > The `API` **SHOULD** provide functions to set a provider and wait for the `initialize` function to return or throw.
 
-The `API` will ensure that the provider is ready or in error before being able to initializing the client.
+The `API` will ensure that the provider initialization is ready or in error before being able to initializing the client.
 
 ```typescript
 // default client

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -112,8 +112,13 @@ Clients may be created in critical code paths, and even per-request in server-si
 The `API` will ensure that the provider is ready or in error before being able to initializing the client.
 
 ```typescript
-await Openfeature.setProviderAndWait(myprovider)
-const client = Openfeature.getClient()
+// default client
+await Openfeature.setProviderAndWait(myprovider);
+const client = Openfeature.getClient();
+
+// named client
+await Openfeature.setProviderAndWait('client-name', myprovider);
+const client = Openfeature.getClient('client-name');
 ```
 
 ### 1.2. Client Usage

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -105,6 +105,17 @@ The name is a logical identifier for the client.
 
 Clients may be created in critical code paths, and even per-request in server-side HTTP contexts. Therefore, in keeping with the principle that OpenFeature should never cause abnormal execution of the first party application, this function should never throw. Abnormal execution in initialization should instead occur during provider registration.
 
+#### Requirement 1.1.8
+
+> The `API` **SHOULD** provide functions to set a provider and wait for the `initialize` function to return or throw.
+
+The `API` will ensure that the provider is ready or in error before being able to initializing the client.
+
+```typescript
+await Openfeature.setProviderAndWait(myprovider)
+const client = Openfeature.getClient()
+```
+
 ### 1.2. Client Usage
 
 #### Requirement 1.2.1

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -113,11 +113,11 @@ This function not only sets the provider, but ensures that the provider is ready
 
 ```java
 // default client
-OpenFeatureAPI.getInstance().setProviderAndWait(myprovider);
-Client client = OpenFeatureAPI.getInstance().getClient();
+OpenFeatureAPI.getInstance().setProviderAndWait(myprovider); // this method blocks until the provider is ready or in error
+Client client = OpenFeatureAPI.getInstance().getClient(); 
 
 // named client
-OpenFeatureAPI.getInstance().setProviderAndWait('client-name', myprovider);
+OpenFeatureAPI.getInstance().setProviderAndWait('client-name', myprovider); // this method blocks until the provider is ready or in error
 Client client = OpenFeatureAPI.getInstance().getClient('client-name');
 ```
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -109,7 +109,7 @@ Clients may be created in critical code paths, and even per-request in server-si
 
 > The `API` **SHOULD** provide functions to set a provider and wait for the `initialize` function to return or throw.
 
-The `API` will ensure that the provider is ready or in error before being able to initializing the client.
+This function not only sets the provider, but ensures that the provider is ready (or in error) before returning or settling.
 
 ```typescript
 // default client

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -121,6 +121,8 @@ await Openfeature.setProviderAndWait('client-name', myprovider);
 const client = Openfeature.getClient('client-name');
 ```
 
+Though it's possible to use [events](./05-events.md) to await provider readiness, such functions can make things simpler for `application authors` and `integrators`.
+
 ### 1.2. Client Usage
 
 #### Requirement 1.2.1


### PR DESCRIPTION
## This PR

Following this [OFEP](https://github.com/open-feature/ofep/blob/main/011-OFEP-sdk-wait-provider-ready.md) adding a **SHOULD** to the spec to have a blocking `setProvider`.