### PR TITLE
fix: correct `event details` type, include `provider name`

### DIFF
--- a/specification/types.md
+++ b/specification/types.md
@@ -125,7 +125,7 @@ A structure defining a provider event payload, including:
 
 A structure defining an event payload, including:
 
-- client name (string, required)
+- provider name (string, required)
 - flags changed (string[], optional)
 - message (string, optional)
 - event metadata ([event metadata](#event-metadata))


### PR DESCRIPTION
We made this change in the spec: https://openfeature.dev/specification/sections/events#requirement-523

But neglected to update it in "types"... it's already implemented in most SDKs.