### PR TITLE
fix: add stale state to provider state diagram

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -411,7 +411,7 @@
         {
             "id": "Requirement 2.4.2",
             "machine_id": "requirement_2_4_2",
-            "content": "The `provider` MAY define a `status` field/accessor which indicates the readiness of the provider, with possible values `NOT_READY`, `READY`, or `ERROR`.",
+            "content": "The `provider` MAY define a `status` field/accessor which indicates the readiness of the provider, with possible values `NOT_READY`, `READY`, `STALE`, or `ERROR`.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -190,7 +190,7 @@ class MyProvider implements Provider {
 
 #### Requirement 2.4.2
 
-> The `provider` **MAY** define a `status` field/accessor which indicates the readiness of the provider, with possible values `NOT_READY`, `READY`, or `ERROR`.
+> The `provider` **MAY** define a `status` field/accessor which indicates the readiness of the provider, with possible values `NOT_READY`, `READY`, `STALE`, or `ERROR`.
 
 Providers without this field can be assumed to be ready immediately.
 
@@ -206,6 +206,9 @@ stateDiagram-v2
     NOT_READY --> READY
     READY --> ERROR
     ERROR --> READY
+    READY --> STALE
+    STALE --> READY
+    STALE --> ERROR
 ```
 
 see [provider status](../types.md#provider-status)


### PR DESCRIPTION
## This PR

Adds missing **STALE** state to provider state diagram. The STALE state was documented in the [Types](https://openfeature.dev/specification/types/#provider-status) section.