### PR TITLE
feat: NOT_READY after provider shutdown

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -444,6 +444,13 @@
             "children": []
         },
         {
+            "id": "Requirement 2.5.2",
+            "machine_id": "requirement_2_5_2",
+            "content": "After a provider's shutdown function has terminated successfully, the provider's state should revert to it's uninitialized state.",
+            "RFC 2119 keyword": null,
+            "children": []
+        },
+        {
             "id": "Requirement 2.6.1",
             "machine_id": "requirement_2_6_1",
             "content": "The provider MAY define an `on context changed` handler, which takes an argument for the previous context and the newly set context, in order to respond to an evaluation context change.",

--- a/specification.json
+++ b/specification.json
@@ -446,8 +446,8 @@
         {
             "id": "Requirement 2.5.2",
             "machine_id": "requirement_2_5_2",
-            "content": "After a provider's shutdown function has terminated successfully, the provider's state should revert to it's uninitialized state.",
-            "RFC 2119 keyword": null,
+            "content": "After a provider's shutdown function has terminated successfully, the provider's state MUST revert to it's uninitialized state.",
+            "RFC 2119 keyword": "MUST",
             "children": []
         },
         {

--- a/specification.json
+++ b/specification.json
@@ -446,7 +446,7 @@
         {
             "id": "Requirement 2.5.2",
             "machine_id": "requirement_2_5_2",
-            "content": "After a provider's shutdown function has terminated successfully, the provider's state MUST revert to it's uninitialized state.",
+            "content": "After a provider's shutdown function has terminated successfully, the provider's state MUST revert to its uninitialized state.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -257,7 +257,7 @@ class MyProvider implements Provider, AutoDisposable {
 
 > After a provider's shutdown function has terminated successfully, the provider's state **MUST** revert to its uninitialized state.
 
-If a provider requires initialization, once it's shut down, it must transition to its initial `NOT_READY` state, so it can be reinitialized.
+If a provider requires initialization, once it's shut down, it must transition to its initial `NOT_READY` state. Some providers may allow re-initialization from this state.
 Providers not requiring initialization are assumed to be ready at all times.
 
 see: [initialization](#24-initialization)

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -257,7 +257,7 @@ class MyProvider implements Provider, AutoDisposable {
 
 > After a provider's shutdown function has terminated successfully, the provider's state **MUST** revert to its uninitialized state.
 
-If a provider requires initialization, once it's shut down, it must transition to its initial `NOT_READY` state. Some providers may allow re-initialization from this state.
+If a provider requires initialization, once it's shut down, it must transition to its initial `NOT_READY` state. Some providers may allow reinitialization from this state.
 Providers not requiring initialization are assumed to be ready at all times.
 
 see: [initialization](#24-initialization)

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -257,7 +257,7 @@ class MyProvider implements Provider, AutoDisposable {
 
 > After a provider's shutdown function has terminated successfully, the provider's state **MUST** revert to its uninitialized state.
 
-If a provider requires initialization, once it's shut down, it should transition to its initial `NOT_READY` state, so it can be reinitialized.
+If a provider requires initialization, once it's shut down, it must transition to its initial `NOT_READY` state, so it can be reinitialized.
 Providers not requiring initialization are assumed to be ready at all times.
 
 see: [initialization](#24-initialization)

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -255,9 +255,9 @@ class MyProvider implements Provider, AutoDisposable {
 
 #### Requirement 2.5.2
 
-> After a provider's shutdown function has terminated successfully, the provider's state **MUST** revert to it's uninitialized state.
+> After a provider's shutdown function has terminated successfully, the provider's state **MUST** revert to its uninitialized state.
 
-If a provider requires initialization, once it's shut down, it should transition to it's initial `NOT_READY` state, so it can be reinitialized.
+If a provider requires initialization, once it's shut down, it should transition to its initial `NOT_READY` state, so it can be reinitialized.
 Providers not requiring initialization are assumed to be ready at all times.
 
 see: [initialization](#24-initialization)

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -255,7 +255,7 @@ class MyProvider implements Provider, AutoDisposable {
 
 #### Requirement 2.5.2
 
-> After a provider's shutdown function has terminated successfully, the provider's state should revert to it's uninitialized state.
+> After a provider's shutdown function has terminated successfully, the provider's state **MUST** revert to it's uninitialized state.
 
 If a provider requires initialization, once it's shut down, it should transition to it's initial `NOT_READY` state, so it can be reinitialized.
 Providers not requiring initialization are assumed to be ready at all times.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -203,12 +203,15 @@ title: Provider State
 stateDiagram-v2
     direction LR
     [*] --> NOT_READY
-    NOT_READY --> READY
+    NOT_READY --> READY:initialize
     READY --> ERROR
     ERROR --> READY
     READY --> STALE
     STALE --> READY
     STALE --> ERROR
+    READY --> NOT_READY:shutdown
+    STALE --> NOT_READY:shutdown
+    ERROR --> NOT_READY:shutdown
 ```
 
 see [provider status](../types.md#provider-status)
@@ -249,6 +252,15 @@ class MyProvider implements Provider, AutoDisposable {
     // close connections, terminate threads or timers, etc...
   }
 ```
+
+#### Requirement 2.5.2
+
+> After a provider's shutdown function has terminated successfully, the provider's state should revert to it's uninitialized state.
+
+If a provider requires initialization, once it's shut down, it should transition to it's initial `NOT_READY` state, so it can be reinitialized.
+Providers not requiring initialization are assumed to be ready at all times.
+
+see: [initialization](#24-initialization)
 
 ### 2.6. Provider context reconciliation
 


### PR DESCRIPTION
Add requirement clarifying providers requiring initialization return to `NOT_READY` after shutdown, as agreed on [here](https://github.com/open-feature/spec/issues/213).

Fixes: https://github.com/open-feature/spec/issues/213