### PR TITLE
fix: add dynamic-context condition to 4.1.4

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -559,11 +559,19 @@
             "children": []
         },
         {
-            "id": "Requirement 4.1.4",
-            "machine_id": "requirement_4_1_4",
-            "content": "The evaluation context MUST be mutable only within the `before` hook.",
-            "RFC 2119 keyword": "MUST",
-            "children": []
+            "id": "Condition 4.1.4",
+            "machine_id": "condition_4_1_4",
+            "content": "The implementation uses the dynamic-context paradigm.",
+            "RFC 2119 keyword": null,
+            "children": [
+                {
+                    "id": "Conditional Requirement 4.1.4.1",
+                    "machine_id": "conditional_requirement_4_1_4_1",
+                    "content": "The evaluation context MUST be mutable only within the `before` hook.",
+                    "RFC 2119 keyword": "MUST",
+                    "children": []
+                }
+            ]
         },
         {
             "id": "Requirement 4.2.1",

--- a/specification/sections/04-hooks.md
+++ b/specification/sections/04-hooks.md
@@ -41,7 +41,13 @@ Hook context exists to provide hooks with information about the invocation.
 
 > The `flag key`, `flag type`, and `default value` properties **MUST** be immutable. If the language does not support immutability, the hook **MUST NOT** modify these properties.
 
-#### Requirement 4.1.4
+#### Condition 4.1.4
+
+> The implementation uses the dynamic-context paradigm.
+
+see: [dynamic-context paradigm](../glossary.md#dynamic-context-paradigm)
+
+##### Conditional Requirement 4.1.4.1
 
 > The evaluation context **MUST** be mutable only within the `before` hook.
 


### PR DESCRIPTION
I neglected to add this qualifier when we released the updates for client (static-context). This requirement isn't relevant when the context is global and can only be changed via `OpenFeature.setContext`.

Thanks for the [find](https://github.com/open-feature/js-sdk/issues/630#issuecomment-1818743111), @lukas-reining .