### PR TITLE
fix: invalid links detected by Docusaurus

### DIFF
--- a/specification/sections/04-hooks.md
+++ b/specification/sections/04-hooks.md
@@ -198,7 +198,7 @@ val = client.get_boolean_value('my-key', False, evaluation_options={
 })
 ```
 
-see: [Flag evaluation options](./01-flag-evaluation.md#)
+see: [Flag evaluation options](./01-flag-evaluation.md#evaluation-options)
 
 #### Requirement 4.5.1
 

--- a/specification/types.md
+++ b/specification/types.md
@@ -100,7 +100,7 @@ A structure containing the following fields:
 
 A structure which supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean`, `string`, or `number`.
 
-This structure is populated by a provider for use by an [Application Author](./glossary.md#application-author) (via the [Evaluation API](./glossary.md#evaluation-api)) or an [Application Integrator](./glossary.md#application-integrator) (via [hooks](./sections/04-hooks.md)).
+This structure is populated by a provider for use by an [Application Author](./glossary.md#application-author) via the [Evaluation API](./glossary.md#evaluation-api) or an [Application Integrator](./glossary.md#application-integrator) via [hooks](./sections/04-hooks.md).
 
 ### Provider Status
 


### PR DESCRIPTION
## This PR

- addresses an invalid anchor
- removed parenthesis that causes a false positive in Docusaurus

### Notes

There's a bug in the invalid link detection in Docusaurus 3 with no ETA on a fix. The PR works around the issue.

https://github.com/facebook/docusaurus/issues/9518
