### PR TITLE
feat: add domain as an openfeature concept

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -38,7 +38,7 @@
         {
             "id": "Requirement 1.1.3",
             "machine_id": "requirement_1_1_3",
-            "content": "The `API` MUST provide a function to bind a given `provider` to one or more clients using a `namespace`. If the namespace already has a bound provider, it is overwritten with the new mapping.",
+            "content": "The `API` MUST provide a function to bind a given `provider` to one or more clients using a `domain`. If the domain already has a bound provider, it is overwritten with the new mapping.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -59,7 +59,7 @@
         {
             "id": "Requirement 1.1.6",
             "machine_id": "requirement_1_1_6",
-            "content": "The `API` MUST provide a function for creating a `client` which accepts the following options:  - namespace (optional): A logical string identifier for mapping clients to provider.",
+            "content": "The `API` MUST provide a function for creating a `client` which accepts the following options:  - domain (optional): A logical string identifier for binding clients to provider.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -80,7 +80,7 @@
         {
             "id": "Requirement 1.2.2",
             "machine_id": "requirement_1_2_2",
-            "content": "The client interface MUST define a `metadata` member or accessor, containing an immutable `namespace` field or accessor of type string, which corresponds to the `namespace` value supplied during client creation.",
+            "content": "The client interface MUST define a `metadata` member or accessor, containing an immutable `domain` field or accessor of type string, which corresponds to the `domain` value supplied during client creation.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -523,14 +523,14 @@
                 {
                     "id": "Conditional Requirement 3.2.2.3",
                     "machine_id": "conditional_requirement_3_2_2_3",
-                    "content": "The API MUST have a method for setting `evaluation context` for a namespace.",
+                    "content": "The API MUST have a method for setting `evaluation context` for a `domain`.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 },
                 {
                     "id": "Conditional Requirement 3.2.2.4",
                     "machine_id": "conditional_requirement_3_2_2_4",
-                    "content": "The API MUST have a mechanism to manage `evaluation context` for an associated namespace.",
+                    "content": "The API MUST have a mechanism to manage `evaluation context` for an associated `domain`.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 }

--- a/specification.json
+++ b/specification.json
@@ -38,7 +38,7 @@
         {
             "id": "Requirement 1.1.3",
             "machine_id": "requirement_1_1_3",
-            "content": "The `API` MUST provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.",
+            "content": "The `API` MUST provide a function to bind a given `provider` to one or more clients using a `namespace`. If the namespace already has a bound provider, it is overwritten with the new mapping.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -59,7 +59,7 @@
         {
             "id": "Requirement 1.1.6",
             "machine_id": "requirement_1_1_6",
-            "content": "The `API` MUST provide a function for creating a `client` which accepts the following options:  - name (optional): A logical string identifier for the client.",
+            "content": "The `API` MUST provide a function for creating a `client` which accepts the following options:  - namespace (optional): A logical string identifier for mapping clients to provider.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -80,7 +80,7 @@
         {
             "id": "Requirement 1.2.2",
             "machine_id": "requirement_1_2_2",
-            "content": "The client interface MUST define a `metadata` member or accessor, containing an immutable `name` field or accessor of type string, which corresponds to the `name` value supplied during client creation.",
+            "content": "The client interface MUST define a `metadata` member or accessor, containing an immutable `namespace` field or accessor of type string, which corresponds to the `namespace` value supplied during client creation.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -523,14 +523,14 @@
                 {
                     "id": "Conditional Requirement 3.2.2.3",
                     "machine_id": "conditional_requirement_3_2_2_3",
-                    "content": "The API MUST have a method for setting `evaluation context` for a provider bound to a named client.",
+                    "content": "The API MUST have a method for setting `evaluation context` for a namespace.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 },
                 {
                     "id": "Conditional Requirement 3.2.2.4",
                     "machine_id": "conditional_requirement_3_2_2_4",
-                    "content": "The API MUST have a a mechanism to manage `evaluation context` for an associated name.",
+                    "content": "The API MUST have a mechanism to manage `evaluation context` for an associated namespace.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 }

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -3,8 +3,8 @@ title: Glossary
 description: A list of terms used within the OpenFeature specification.
 sidebar_position: 1
 ---
-<!-- omit from toc -->
-# Glossary 
+
+# Glossary <!-- omit from toc -->
 
 This document defines some terms that are used across this specification.
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -13,37 +13,39 @@ This document defines some terms that are used across this specification.
 
 <!-- toc -->
 
-- [Feature Flag](#feature-flag)
-- [User Roles](#user-roles)
-  - [Application Author](#application-author)
-  - [Application Integrator](#application-integrator)
-  - [Provider Author](#provider-author)
-  - [Integration Author](#integration-author)
-  - [Library Author](#library-author)
-- [Common](#common)
-  - [Feature Flag SDK](#feature-flag-sdk)
-  - [Client-Side SDK](#client-side-sdk)
-  - [Server-Side SDK](#server-side-sdk)
-  - [Feature Flag API](#feature-flag-api)
-  - [Evaluation API](#evaluation-api)
-  - [Flag Management System](#flag-management-system)
-  - [Provider](#provider)
-  - [Integration](#integration)
-  - [Evaluation Context](#evaluation-context)
-  - [Evaluating Flag Values](#evaluating-flag-values)
-  - [Resolving Flag Values](#resolving-flag-values)
-- [Flagging specifics](#flagging-specifics)
-  - [Flag](#flag)
-  - [Flag Key](#flag-key)
-  - [Variant](#variant)
-  - [Values](#values)
-  - [Targeting](#targeting)
-  - [Targeting Key](#targeting-key)
-  - [Fractional Evaluation](#fractional-evaluation)
-  - [Rule](#rule)
-- [SDK Paradigms](#sdk-paradigms)
-  - [Dynamic-Context Paradigm](#dynamic-context-paradigm)
-  - [Static-Context Paradigm](#static-context-paradigm)
+- [Glossary](#glossary)
+  - [Feature Flag](#feature-flag)
+  - [User Roles](#user-roles)
+    - [Application Author](#application-author)
+    - [Application Integrator](#application-integrator)
+    - [Provider Author](#provider-author)
+    - [Integration Author](#integration-author)
+    - [Library Author](#library-author)
+  - [Common](#common)
+    - [Feature Flag SDK](#feature-flag-sdk)
+    - [Client-Side SDK](#client-side-sdk)
+    - [Server-Side SDK](#server-side-sdk)
+    - [Feature Flag API](#feature-flag-api)
+    - [Evaluation API](#evaluation-api)
+    - [Flag Management System](#flag-management-system)
+    - [Provider](#provider)
+    - [Namespace](#namespace)
+    - [Integration](#integration)
+    - [Evaluation Context](#evaluation-context)
+    - [Evaluating Flag Values](#evaluating-flag-values)
+    - [Resolving Flag Values](#resolving-flag-values)
+  - [Flagging specifics](#flagging-specifics)
+    - [Flag](#flag)
+    - [Flag Key](#flag-key)
+    - [Variant](#variant)
+    - [Values](#values)
+    - [Targeting](#targeting)
+    - [Targeting Key](#targeting-key)
+    - [Fractional Evaluation](#fractional-evaluation)
+    - [Rule](#rule)
+  - [SDK Paradigms](#sdk-paradigms)
+    - [Dynamic-Context Paradigm](#dynamic-context-paradigm)
+    - [Static-Context Paradigm](#static-context-paradigm)
 
 <!-- tocstop -->
 
@@ -107,7 +109,9 @@ A source-of-truth for flag values and rules. Flag management systems may include
 
 An SDK-compliant implementation which resolves flag values from a particular flag management system, allowing the use of the [Evaluation API](./sections/01-flag-evaluation.md#13-flag-evaluation) as an abstraction for the system in question.
 
-Providers can be used in two ways. Client-specific providers are active for specific clients, based on their name. The default provider is used if there are no client-specific mappings setup.
+### Namespace
+
+An identifier which logically associates clients with providers, allowing for multiple providers to be used simultaneously within a single application.
 
 ### Integration
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -3,8 +3,8 @@ title: Glossary
 description: A list of terms used within the OpenFeature specification.
 sidebar_position: 1
 ---
-
-# Glossary
+<!-- omit from toc -->
+# Glossary 
 
 This document defines some terms that are used across this specification.
 
@@ -13,39 +13,38 @@ This document defines some terms that are used across this specification.
 
 <!-- toc -->
 
-- [Glossary](#glossary)
-  - [Feature Flag](#feature-flag)
-  - [User Roles](#user-roles)
-    - [Application Author](#application-author)
-    - [Application Integrator](#application-integrator)
-    - [Provider Author](#provider-author)
-    - [Integration Author](#integration-author)
-    - [Library Author](#library-author)
-  - [Common](#common)
-    - [Feature Flag SDK](#feature-flag-sdk)
-    - [Client-Side SDK](#client-side-sdk)
-    - [Server-Side SDK](#server-side-sdk)
-    - [Feature Flag API](#feature-flag-api)
-    - [Evaluation API](#evaluation-api)
-    - [Flag Management System](#flag-management-system)
-    - [Provider](#provider)
-    - [Namespace](#namespace)
-    - [Integration](#integration)
-    - [Evaluation Context](#evaluation-context)
-    - [Evaluating Flag Values](#evaluating-flag-values)
-    - [Resolving Flag Values](#resolving-flag-values)
-  - [Flagging specifics](#flagging-specifics)
-    - [Flag](#flag)
-    - [Flag Key](#flag-key)
-    - [Variant](#variant)
-    - [Values](#values)
-    - [Targeting](#targeting)
-    - [Targeting Key](#targeting-key)
-    - [Fractional Evaluation](#fractional-evaluation)
-    - [Rule](#rule)
-  - [SDK Paradigms](#sdk-paradigms)
-    - [Dynamic-Context Paradigm](#dynamic-context-paradigm)
-    - [Static-Context Paradigm](#static-context-paradigm)
+- [Feature Flag](#feature-flag)
+- [User Roles](#user-roles)
+  - [Application Author](#application-author)
+  - [Application Integrator](#application-integrator)
+  - [Provider Author](#provider-author)
+  - [Integration Author](#integration-author)
+  - [Library Author](#library-author)
+- [Common](#common)
+  - [Feature Flag SDK](#feature-flag-sdk)
+  - [Client-Side SDK](#client-side-sdk)
+  - [Server-Side SDK](#server-side-sdk)
+  - [Feature Flag API](#feature-flag-api)
+  - [Evaluation API](#evaluation-api)
+  - [Flag Management System](#flag-management-system)
+  - [Provider](#provider)
+  - [Namespace](#namespace)
+  - [Integration](#integration)
+  - [Evaluation Context](#evaluation-context)
+  - [Evaluating Flag Values](#evaluating-flag-values)
+  - [Resolving Flag Values](#resolving-flag-values)
+- [Flagging specifics](#flagging-specifics)
+  - [Flag](#flag)
+  - [Flag Key](#flag-key)
+  - [Variant](#variant)
+  - [Values](#values)
+  - [Targeting](#targeting)
+  - [Targeting Key](#targeting-key)
+  - [Fractional Evaluation](#fractional-evaluation)
+  - [Rule](#rule)
+- [SDK Paradigms](#sdk-paradigms)
+  - [Dynamic-Context Paradigm](#dynamic-context-paradigm)
+  - [Static-Context Paradigm](#static-context-paradigm)
 
 <!-- tocstop -->
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -28,7 +28,7 @@ This document defines some terms that are used across this specification.
   - [Evaluation API](#evaluation-api)
   - [Flag Management System](#flag-management-system)
   - [Provider](#provider)
-  - [Namespace](#namespace)
+  - [Domain](#domain)
   - [Integration](#integration)
   - [Evaluation Context](#evaluation-context)
   - [Evaluating Flag Values](#evaluating-flag-values)
@@ -108,9 +108,9 @@ A source-of-truth for flag values and rules. Flag management systems may include
 
 An SDK-compliant implementation which resolves flag values from a particular flag management system, allowing the use of the [Evaluation API](./sections/01-flag-evaluation.md#13-flag-evaluation) as an abstraction for the system in question.
 
-### Namespace
+### Domain
 
-An identifier which logically associates clients with providers, allowing for multiple providers to be used simultaneously within a single application.
+An identifier which logically binds clients with providers, allowing for multiple providers to be used simultaneously within a single application.
 
 ### Integration
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -31,7 +31,8 @@ It's important that multiple instances of the `API` not be active, so that state
 OpenFeature.setProvider(new MyProvider());
 ```
 
-This provider is used if a client is not bound to a specific provider through its name.
+The example above sets the default provider.
+This provider is used if a client is not bound to a specific provider through its [namespace](../glossary.md#namespace).
 
 See [provider](./02-providers.md), [creating clients](#creating-clients).
 
@@ -40,7 +41,7 @@ See [provider](./02-providers.md), [creating clients](#creating-clients).
 > The `provider mutator` function **MUST** invoke the `initialize` function on the newly registered provider before using it to resolve flag values.
 
 Application authors can await the newly set `provider's` readiness using the `PROVIDER_READY` event.
-Provider instances which are already active (because they have been bound to other `names` or otherwise) need not be initialized again.
+Provider instances which are already active (because they have been bound to other `namespaces` or otherwise) need not be initialized again.
 The `provider's` readiness can state can be determined from its `status` member/accessor.
 
 See [event handlers and initialization](./05-events.md#event-handlers-and-initialization), [provider initialization](./02-providers.md#24-initialization).
@@ -50,7 +51,7 @@ See [event handlers and initialization](./05-events.md#event-handlers-and-initia
 >  The `provider mutator` function **MUST** invoke the `shutdown` function on the previously registered provider once it's no longer being used to resolve flag values.
 
 When a provider is no longer in use, it should be disposed of using its `shutdown` mechanism.
-Provider instances which are bound to multiple names won't be shut down until the last binding is removed.
+Provider instances which are bound to multiple `namespaces` won't be shut down until the last binding is removed.
 
 see: [shutdown](./02-providers.md#25-shutdown), [setting a provider](#setting-a-provider)
 
@@ -61,26 +62,28 @@ see: [shutdown](./02-providers.md#25-shutdown), [setting a provider](#setting-a-
 This function not only sets the provider, but ensures that the provider is ready (or in error) before returning or settling.
 
 ```java
-// default client
+// default provider
 OpenFeatureAPI.getInstance().setProviderAndWait(myprovider); // this method blocks until the provider is ready or in error
+// client uses the default provider
 Client client = OpenFeatureAPI.getInstance().getClient(); 
 
-// named client
-OpenFeatureAPI.getInstance().setProviderAndWait('client-name', myprovider); // this method blocks until the provider is ready or in error
-Client client = OpenFeatureAPI.getInstance().getClient('client-name');
+// namespaced provider
+OpenFeatureAPI.getInstance().setProviderAndWait('my-namespace', myprovider); // this method blocks until the provider is ready or in error
+// client uses provider associated with the namespace
+Client client = OpenFeatureAPI.getInstance().getClient('my-namespace');
 ```
 
 Though it's possible to use [events](./05-events.md) to await provider readiness, such functions can make things simpler for `application authors` and `integrators`.
 
 #### Requirement 1.1.3
 
-> The `API` **MUST** provide a function to bind a given `provider` to one or more client `name`s. If the client-name already has a bound provider, it is overwritten with the new mapping.
+> The `API` **MUST** provide a function to bind a given `provider` to one or more clients using a `namespace`. If the namespace already has a bound provider, it is overwritten with the new mapping.
 
 ```java
-OpenFeature.setProvider("client-name", new MyProvider());
+OpenFeature.setProvider("my-namespace", new MyProvider());
 ```
 
-Named clients can be associated with a particular provider by supplying a matching name when the provider is set.
+Clients can be associated with a particular provider by supplying a matching namespace when the provider is set.
 
 See [creating clients](#creating-clients).
 
@@ -104,6 +107,13 @@ See [hooks](./04-hooks.md) for details.
 OpenFeature.getProviderMetadata();
 ```
 
+TODO: Add text explaining that this is for a namespace
+
+```typescript
+// example provider accessor
+OpenFeature.getProviderMetadata("my-namespace");
+```
+
 See [provider](./02-providers.md) for details.
 
 ### Creating clients
@@ -112,17 +122,21 @@ See [provider](./02-providers.md) for details.
 
 > The `API` **MUST** provide a function for creating a `client` which accepts the following options:
 >
-> - name (optional): A logical string identifier for the client.
+> - namespace (optional): A logical string identifier for mapping clients to provider.
 
 ```java
 // example client creation and retrieval
-OpenFeature.getClient("my-named-client");
+OpenFeature.getClient();
 ```
 
-The name is a logical identifier for the client which may be associated with a particular provider by the application integrator.
-If a client name is not bound to a particular provider, the client is associated with the default provider.
+TODO: Text explaining the namespace stuff
 
-See [setting a provider](#setting-a-provider) for details.
+```java
+// example client creation and retrieval using a namespace
+OpenFeature.getClient("my-namespace");
+```
+
+See [setting a provider](#setting-a-provider), [namespace](../glossary.md#namespace) for details.
 
 #### Requirement 1.1.7
 
@@ -145,11 +159,14 @@ See [hooks](./04-hooks.md) for details.
 
 #### Requirement 1.2.2
 
-> The client interface **MUST** define a `metadata` member or accessor, containing an immutable `name` field or accessor of type string, which corresponds to the `name` value supplied during client creation.
+> The client interface **MUST** define a `metadata` member or accessor, containing an immutable `namespace` field or accessor of type string, which corresponds to the `namespace` value supplied during client creation.
 
 ```typescript
-client.getMetadata().getName(); // "my-client"
+client.getMetadata().getNamespace(); // "my-namespace"
 ```
+
+In previous drafts, this property was called `name`.
+For backwards compatibility, implementations should consider `name` an alias to `namespace`.
 
 ### 1.3. Flag Evaluation
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -107,7 +107,7 @@ See [hooks](./04-hooks.md) for details.
 OpenFeature.getProviderMetadata();
 ```
 
-It must be possible to access provider metadata using a `domain`.
+It's possible to access provider metadata using a `domain`.
 If a provider has not be registered under the requested domain, the default provider metadata is returned.
 
 ```typescript
@@ -130,7 +130,7 @@ See [provider](./02-providers.md), [domain](../glossary.md#domain) for details.
 OpenFeature.getClient();
 ```
 
-It must be possible to create a client that is associated with a `domain`.
+It's possible to create a client that is associated with a `domain`.
 The client will use a provider in the same `domain` if one exists, otherwise, the default provide is used.
 
 ```java

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -107,7 +107,8 @@ See [hooks](./04-hooks.md) for details.
 OpenFeature.getProviderMetadata();
 ```
 
-TODO: Add text explaining that this is for a namespace
+It must be possible to access provider metadata using a namespace.
+If a provider has not be registered under the requested namespace, the default provider metadata is returned.
 
 ```typescript
 // example provider accessor
@@ -129,7 +130,8 @@ See [provider](./02-providers.md) for details.
 OpenFeature.getClient();
 ```
 
-TODO: Text explaining the namespace stuff
+It must be possible to create a client that is associated with a namespace.
+The client will use a provider in the same namespace if one exists, otherwise, the default provide is used.
 
 ```java
 // example client creation and retrieval using a namespace

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -32,28 +32,28 @@ OpenFeature.setProvider(new MyProvider());
 ```
 
 The example above sets the default provider.
-This provider is used if a client is not bound to a specific provider through its [namespace](../glossary.md#namespace).
+This provider is used if a client is not bound to a specific provider via a [domain](../glossary.md#domain).
 
-See [provider](./02-providers.md), [creating clients](#creating-clients).
+See [provider](./02-providers.md), [creating clients](#creating-clients) for details.
 
 #### Requirement 1.1.2.2
 
 > The `provider mutator` function **MUST** invoke the `initialize` function on the newly registered provider before using it to resolve flag values.
 
 Application authors can await the newly set `provider's` readiness using the `PROVIDER_READY` event.
-Provider instances which are already active (because they have been bound to other `namespaces` or otherwise) need not be initialized again.
+Provider instances which are already active (because they have been bound to another `domain` or otherwise) need not be initialized again.
 The `provider's` readiness can state can be determined from its `status` member/accessor.
 
-See [event handlers and initialization](./05-events.md#event-handlers-and-initialization), [provider initialization](./02-providers.md#24-initialization).
+See [event handlers and initialization](./05-events.md#event-handlers-and-initialization), [provider initialization](./02-providers.md#24-initialization), [domain](../glossary.md#domain) for details.
 
 #### Requirement 1.1.2.3
 
 >  The `provider mutator` function **MUST** invoke the `shutdown` function on the previously registered provider once it's no longer being used to resolve flag values.
 
 When a provider is no longer in use, it should be disposed of using its `shutdown` mechanism.
-Provider instances which are bound to multiple `namespaces` won't be shut down until the last binding is removed.
+Provider instances which are bound to multiple `domains` won't be shut down until the last binding is removed.
 
-see: [shutdown](./02-providers.md#25-shutdown), [setting a provider](#setting-a-provider)
+see [shutdown](./02-providers.md#25-shutdown), [setting a provider](#setting-a-provider), [domain](../glossary.md#domain) for details.
 
 #### Requirement 1.1.2.4
 
@@ -67,25 +67,25 @@ OpenFeatureAPI.getInstance().setProviderAndWait(myprovider); // this method bloc
 // client uses the default provider
 Client client = OpenFeatureAPI.getInstance().getClient(); 
 
-// namespaced provider
-OpenFeatureAPI.getInstance().setProviderAndWait('my-namespace', myprovider); // this method blocks until the provider is ready or in error
-// client uses provider associated with the namespace
-Client client = OpenFeatureAPI.getInstance().getClient('my-namespace');
+// provider associated with domain-1
+OpenFeatureAPI.getInstance().setProviderAndWait('domain-1', myprovider); // this method blocks until the provider is ready or in error
+// client uses provider associated with the domain named 'domain-1'
+Client client = OpenFeatureAPI.getInstance().getClient('domain-1');
 ```
 
 Though it's possible to use [events](./05-events.md) to await provider readiness, such functions can make things simpler for `application authors` and `integrators`.
 
 #### Requirement 1.1.3
 
-> The `API` **MUST** provide a function to bind a given `provider` to one or more clients using a `namespace`. If the namespace already has a bound provider, it is overwritten with the new mapping.
+> The `API` **MUST** provide a function to bind a given `provider` to one or more clients using a `domain`. If the domain already has a bound provider, it is overwritten with the new mapping.
 
 ```java
-OpenFeature.setProvider("my-namespace", new MyProvider());
+OpenFeature.setProvider("domain-1", new MyProvider());
 ```
 
-Clients can be associated with a particular provider by supplying a matching namespace when the provider is set.
+Clients can be associated with a particular provider by supplying a matching `domain`` when the provider is set.
 
-See [creating clients](#creating-clients).
+See [creating clients](#creating-clients), [domain](../glossary.md#domain) for details.
 
 #### Requirement 1.1.4
 
@@ -107,15 +107,15 @@ See [hooks](./04-hooks.md) for details.
 OpenFeature.getProviderMetadata();
 ```
 
-It must be possible to access provider metadata using a namespace.
-If a provider has not be registered under the requested namespace, the default provider metadata is returned.
+It must be possible to access provider metadata using a `domain`.
+If a provider has not be registered under the requested domain, the default provider metadata is returned.
 
 ```typescript
 // example provider accessor
-OpenFeature.getProviderMetadata("my-namespace");
+OpenFeature.getProviderMetadata("domain-1");
 ```
 
-See [provider](./02-providers.md) for details.
+See [provider](./02-providers.md), [domain](../glossary.md#domain) for details.
 
 ### Creating clients
 
@@ -123,22 +123,22 @@ See [provider](./02-providers.md) for details.
 
 > The `API` **MUST** provide a function for creating a `client` which accepts the following options:
 >
-> - namespace (optional): A logical string identifier for mapping clients to provider.
+> - domain (optional): A logical string identifier for binding clients to provider.
 
 ```java
 // example client creation and retrieval
 OpenFeature.getClient();
 ```
 
-It must be possible to create a client that is associated with a namespace.
-The client will use a provider in the same namespace if one exists, otherwise, the default provide is used.
+It must be possible to create a client that is associated with a `domain`.
+The client will use a provider in the same `domain` if one exists, otherwise, the default provide is used.
 
 ```java
-// example client creation and retrieval using a namespace
-OpenFeature.getClient("my-namespace");
+// example client creation and retrieval using a domain
+OpenFeature.getClient("domain-1");
 ```
 
-See [setting a provider](#setting-a-provider), [namespace](../glossary.md#namespace) for details.
+See [setting a provider](#setting-a-provider), [domain](../glossary.md#domain) for details.
 
 #### Requirement 1.1.7
 
@@ -161,14 +161,14 @@ See [hooks](./04-hooks.md) for details.
 
 #### Requirement 1.2.2
 
-> The client interface **MUST** define a `metadata` member or accessor, containing an immutable `namespace` field or accessor of type string, which corresponds to the `namespace` value supplied during client creation.
+> The client interface **MUST** define a `metadata` member or accessor, containing an immutable `domain` field or accessor of type string, which corresponds to the `domain` value supplied during client creation.
 
 ```typescript
-client.getMetadata().getNamespace(); // "my-namespace"
+client.getMetadata().getDomain(); // "domain-1"
 ```
 
 In previous drafts, this property was called `name`.
-For backwards compatibility, implementations should consider `name` an alias to `namespace`.
+For backwards compatibility, implementations should consider `name` an alias to `domain`.
 
 ### 1.3. Flag Evaluation
 

--- a/specification/sections/03-evaluation-context.md
+++ b/specification/sections/03-evaluation-context.md
@@ -79,19 +79,19 @@ In the static-context paradigm, context is global. The client and invocation can
 
 ##### Conditional Requirement 3.2.2.3
 
-> The API **MUST** have a method for setting `evaluation context` for a namespace.
+> The API **MUST** have a method for setting `evaluation context` for a `domain`.
 
-In the static-context paradigm, provider specific context can be set using the associated namespace.
+In the static-context paradigm, provider specific context can be set using the associated `domain`.
 The global context is used if there is no matching provider specific context.
 
-See [setting a provider](./01-flag-evaluation.md#setting-a-provider) for details.
+See [setting a provider](./01-flag-evaluation.md#setting-a-provider), [domain](../glossary.md#domain) for details.
 
 ##### Conditional Requirement 3.2.2.4
 
-> The API **MUST** have a mechanism to manage `evaluation context` for an associated namespace.
+> The API **MUST** have a mechanism to manage `evaluation context` for an associated `domain`.
 
 In the static-context paradigm, it must be possible to create and remove provider-specific context.
-See [setting a provider](./01-flag-evaluation.md#setting-a-provider) for details.
+See [setting a provider](./01-flag-evaluation.md#setting-a-provider), [domain](../glossary.md#domain) for details.
 
 #### Requirement 3.2.3
 

--- a/specification/sections/03-evaluation-context.md
+++ b/specification/sections/03-evaluation-context.md
@@ -79,16 +79,16 @@ In the static-context paradigm, context is global. The client and invocation can
 
 ##### Conditional Requirement 3.2.2.3
 
-> The API **MUST** have a method for setting `evaluation context` for a provider bound to a named client.
+> The API **MUST** have a method for setting `evaluation context` for a namespace.
 
-In the static-context paradigm, provider specific context can be set using the associated name.
+In the static-context paradigm, provider specific context can be set using the associated namespace.
 The global context is used if there is no matching provider specific context.
 
 See [setting a provider](./01-flag-evaluation.md#setting-a-provider) for details.
 
 ##### Conditional Requirement 3.2.2.4
 
-> The API **MUST** have a a mechanism to manage `evaluation context` for an associated name.
+> The API **MUST** have a mechanism to manage `evaluation context` for an associated namespace.
 
 In the static-context paradigm, it must be possible to create and remove provider-specific context.
 See [setting a provider](./01-flag-evaluation.md#setting-a-provider) for details.

--- a/specification/sections/03-evaluation-context.md
+++ b/specification/sections/03-evaluation-context.md
@@ -90,7 +90,7 @@ See [setting a provider](./01-flag-evaluation.md#setting-a-provider), [domain](.
 
 > The API **MUST** have a mechanism to manage `evaluation context` for an associated `domain`.
 
-In the static-context paradigm, it must be possible to create and remove provider-specific context.
+In the static-context paradigm, it's possible to create and remove provider-specific context.
 See [setting a provider](./01-flag-evaluation.md#setting-a-provider), [domain](../glossary.md#domain) for details.
 
 #### Requirement 3.2.3

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -42,7 +42,7 @@ see: [provider event types](./../types.md#provider-events) and [event handlers](
 
 > When a `provider` signals the occurrence of a particular `event`, event handlers on clients which are not associated with that provider **MUST NOT** run.
 
-Providers bound to a named client constitute their own "events scope".
+Providers bound to a `namespace` constitute their own "events scope".
 
 see: [setting a provider](./01-flag-evaluation.md#setting-a-provider)
 
@@ -83,9 +83,9 @@ see: [provider events](#51-provider-events), [`provider event types`](../types.m
 > The `event details` **MUST** contain the `provider name` associated with the event.
 
 The `provider name` indicates the provider from which the event originated.
-This is especially relevant for global event handlers used for general monitoring, such as alerting on provider errors. 
+This is especially relevant for global event handlers used for general monitoring, such as alerting on provider errors.
 
-See [setting a provider](./01-flag-evaluation.md#setting-a-provider), [creating clients](./01-flag-evaluation.md#creating-clients). 
+See [setting a provider](./01-flag-evaluation.md#setting-a-provider), [creating clients](./01-flag-evaluation.md#creating-clients).
 
 #### Requirement 5.2.4
 

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -42,9 +42,9 @@ see: [provider event types](./../types.md#provider-events) and [event handlers](
 
 > When a `provider` signals the occurrence of a particular `event`, event handlers on clients which are not associated with that provider **MUST NOT** run.
 
-Providers bound to a `namespace` constitute their own "events scope".
+Providers bound to a `domain` constitute their own "events scope".
 
-see: [setting a provider](./01-flag-evaluation.md#setting-a-provider)
+see [setting a provider](./01-flag-evaluation.md#setting-a-provider), [domain](../glossary.md#domain) for details.
 
 #### Requirement 5.1.4
 


### PR DESCRIPTION
## This PR

- defines `domain` as a concept
- updates references to client name to use `domain`
- add `domain` as client metadata

### Related Issues

Fixes #228

### Follow-up Tasks

- Update the readme template
- Update the openfeature.dev SDK compatibility table
