### PR TITLE
feat: internal provider state, new client events

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -460,8 +460,8 @@
                 {
                     "id": "Conditional Requirement 2.4.2.1",
                     "machine_id": "conditional_requirement_2_4_2_1",
-                    "content": "If the provider's `initialize` function fails to ready the provider to evaluate flags, it MUST abnormally terminate.",
-                    "RFC 2119 keyword": "MUST",
+                    "content": "If the provider's `initialize` function fails to render the provider ready to evaluate flags, it SHOULD abnormally terminate.",
+                    "RFC 2119 keyword": "SHOULD",
                     "children": []
                 }
             ]

--- a/specification.json
+++ b/specification.json
@@ -333,15 +333,15 @@
         {
             "id": "Requirement 1.7.6",
             "machine_id": "requirement_1_7_6",
-            "content": "The client SHOULD default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `NOT_READY`.",
-            "RFC 2119 keyword": "SHOULD",
+            "content": "The client MUST default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `NOT_READY`.",
+            "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 1.7.7",
             "machine_id": "requirement_1_7_7",
-            "content": "The client SHOULD default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `PROVIDER_FATAL`.",
-            "RFC 2119 keyword": "SHOULD",
+            "content": "The client MUST default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `PROVIDER_FATAL`.",
+            "RFC 2119 keyword": "MUST",
             "children": []
         },
         {

--- a/specification.json
+++ b/specification.json
@@ -1025,14 +1025,14 @@
                 {
                     "id": "Conditional Requirement 5.3.4.2",
                     "machine_id": "conditional_requirement_5_3_4_2",
-                    "content": "If the provider's `on context changed` function terminates normally, associated `PROVIDER_CONTEXT_CHANGED` handlers MUST run.",
+                    "content": "If the provider's `on context changed` function terminates normally, and no other invocations have yet to terminate, associated `PROVIDER_CONTEXT_CHANGED` handlers MUST run.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 },
                 {
                     "id": "Conditional Requirement 5.3.4.3",
                     "machine_id": "conditional_requirement_5_3_4_3",
-                    "content": "If the provider's `on context changed` function terminates abnormally, associated `PROVIDER_ERROR` handlers MUST run.",
+                    "content": "If the provider's `on context changed` function terminates abnormally, and no other invocations have yet to terminate, associated `PROVIDER_ERROR` handlers MUST run.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 }

--- a/specification.json
+++ b/specification.json
@@ -288,6 +288,49 @@
             "children": []
         },
         {
+            "id": "Requirement 1.7.1",
+            "machine_id": "requirement_1_7_1",
+            "content": "The `client` MUST define a `provider status` accessor which indicates the readiness of the associated provider, with possible values `NOT_READY`, `READY`, `STALE`, or `ERROR`.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Condition 1.7.2",
+            "machine_id": "condition_1_7_2",
+            "content": "The implementation uses the static-context paradigm.",
+            "RFC 2119 keyword": null,
+            "children": [
+                {
+                    "id": "Conditional Requirement 1.7.2.1",
+                    "machine_id": "conditional_requirement_1_7_2_1",
+                    "content": "In addition to `NOT_READY`, `READY`, `STALE`, or `ERROR`, the  `provider status` accessor must support possible value `CONTEXT_PENDING`.",
+                    "RFC 2119 keyword": null,
+                    "children": []
+                }
+            ]
+        },
+        {
+            "id": "Requirement 1.7.3",
+            "machine_id": "requirement_1_7_3",
+            "content": "The client's `provider status` accessor MUST indicate `READY` if the `initialize` function of the associated provider terminates normally.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Requirement 1.7.4",
+            "machine_id": "requirement_1_7_4",
+            "content": "The client's `provider status` accessor MUST indicate `ERROR` if the `initialize` function of the associated provider terminates abnormally.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Requirement 1.7.5",
+            "machine_id": "requirement_1_7_5",
+            "content": "The client SHOULD indicate an error if flag resolution is attempted before the provider is ready.",
+            "RFC 2119 keyword": "SHOULD",
+            "children": []
+        },
+        {
             "id": "Requirement 2.1.1",
             "machine_id": "requirement_2_1_1",
             "content": "The provider interface MUST define a `metadata` member or accessor, containing a `name` field or accessor of type string, which identifies the provider implementation.",
@@ -409,32 +452,19 @@
             "children": []
         },
         {
-            "id": "Requirement 2.4.2",
-            "machine_id": "requirement_2_4_2",
-            "content": "The `provider` MAY define a `status` field/accessor which indicates the readiness of the provider, with possible values `NOT_READY`, `READY`, `STALE`, or `ERROR`.",
-            "RFC 2119 keyword": "MAY",
-            "children": []
-        },
-        {
-            "id": "Requirement 2.4.3",
-            "machine_id": "requirement_2_4_3",
-            "content": "The provider MUST set its `status` field/accessor to `READY` if its `initialize` function terminates normally.",
-            "RFC 2119 keyword": "MUST",
-            "children": []
-        },
-        {
-            "id": "Requirement 2.4.4",
-            "machine_id": "requirement_2_4_4",
-            "content": "The provider MUST set its `status` field to `ERROR` if its `initialize` function terminates abnormally.",
-            "RFC 2119 keyword": "MUST",
-            "children": []
-        },
-        {
-            "id": "Requirement 2.4.5",
-            "machine_id": "requirement_2_4_5",
-            "content": "The provider SHOULD indicate an error if flag resolution is attempted before the provider is ready.",
-            "RFC 2119 keyword": "SHOULD",
-            "children": []
+            "id": "Condition 2.4.2",
+            "machine_id": "condition_2_4_2",
+            "content": "The provider defines an `initialize` function.",
+            "RFC 2119 keyword": null,
+            "children": [
+                {
+                    "id": "Conditional Requirement 2.4.2.1",
+                    "machine_id": "conditional_requirement_2_4_2_1",
+                    "content": "If the provider's `initialize` function fails to ready the provider to evaluate flags, it MUST abnormally terminate.",
+                    "RFC 2119 keyword": "MUST",
+                    "children": []
+                }
+            ]
         },
         {
             "id": "Requirement 2.5.1",
@@ -453,7 +483,7 @@
         {
             "id": "Requirement 2.6.1",
             "machine_id": "requirement_2_6_1",
-            "content": "The provider MAY define an `on context changed` handler, which takes an argument for the previous context and the newly set context, in order to respond to an evaluation context change.",
+            "content": "The provider MAY define an `on context changed` function, which takes an argument for the previous context and the newly set context, in order to respond to an evaluation context change.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },
@@ -552,14 +582,14 @@
                 {
                     "id": "Conditional Requirement 3.2.4.1",
                     "machine_id": "conditional_requirement_3_2_4_1",
-                    "content": "When the global `evaluation context` is set, the `on context changed` handler MUST run.",
+                    "content": "When the global `evaluation context` is set, the `on context changed` function MUST run.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 },
                 {
                     "id": "Conditional Requirement 3.2.4.2",
                     "machine_id": "conditional_requirement_3_2_4_2",
-                    "content": "When the `evaluation context` for a specific provider is set, the `on context changed` handler MUST only run on the associated provider.",
+                    "content": "When the `evaluation context` for a specific provider is set, the `on context changed` function MUST only run on the associated provider.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 }
@@ -960,8 +990,8 @@
                 {
                     "id": "Conditional Requirement 5.3.4.1",
                     "machine_id": "conditional_requirement_5_3_4_1",
-                    "content": "When the provider's `on context changed` is called, the provider MAY emit the `PROVIDER_STALE` event, and transition to the `STALE` state.",
-                    "RFC 2119 keyword": "MAY",
+                    "content": "While the provider's `on context changed` function is executing, associated `PROVIDER_CONTEXT_PENDING` handlers MUST run.",
+                    "RFC 2119 keyword": "MUST",
                     "children": []
                 },
                 {
@@ -979,6 +1009,13 @@
                     "children": []
                 }
             ]
+        },
+        {
+            "id": "Requirement 5.3.5",
+            "machine_id": "requirement_5_3_5",
+            "content": "If the provider emits an event, the value of the client's `provider status` MUST be updated accordingly.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
         }
     ]
 }

--- a/specification.json
+++ b/specification.json
@@ -290,7 +290,7 @@
         {
             "id": "Requirement 1.7.1",
             "machine_id": "requirement_1_7_1",
-            "content": "The `client` MUST define a `provider status` accessor which indicates the readiness of the associated provider, with possible values `NOT_READY`, `READY`, `STALE`, or `ERROR`.",
+            "content": "The `client` MUST define a `provider status` accessor which indicates the readiness of the associated provider, with possible values `NOT_READY`, `READY`, `STALE`, `ERROR`, or `FATAL`.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -303,7 +303,7 @@
                 {
                     "id": "Conditional Requirement 1.7.2.1",
                     "machine_id": "conditional_requirement_1_7_2_1",
-                    "content": "In addition to `NOT_READY`, `READY`, `STALE`, or `ERROR`, the  `provider status` accessor must support possible value `CONTEXT_PENDING`.",
+                    "content": "In addition to `NOT_READY`, `READY`, `STALE`, or `ERROR`, the  `provider status` accessor must support possible value `RECONCILING`.",
                     "RFC 2119 keyword": null,
                     "children": []
                 }
@@ -326,7 +326,28 @@
         {
             "id": "Requirement 1.7.5",
             "machine_id": "requirement_1_7_5",
-            "content": "The client SHOULD indicate an error if flag resolution is attempted before the provider is ready.",
+            "content": "The client's `provider status` accessor MUST indicate `FATAL` if the `initialize` function of the associated provider terminates abnormally and indicates `error code` `PROVIDER_FATAL`.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Requirement 1.7.6",
+            "machine_id": "requirement_1_7_6",
+            "content": "The client SHOULD default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `NOT_READY`.",
+            "RFC 2119 keyword": "SHOULD",
+            "children": []
+        },
+        {
+            "id": "Requirement 1.7.7",
+            "machine_id": "requirement_1_7_7",
+            "content": "The client SHOULD default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `PROVIDER_FATAL`.",
+            "RFC 2119 keyword": "SHOULD",
+            "children": []
+        },
+        {
+            "id": "Requirement 1.7.8",
+            "machine_id": "requirement_1_7_8",
+            "content": "Implementations SHOULD propagate the `error code` returned from any provider lifecycle methods.",
             "RFC 2119 keyword": "SHOULD",
             "children": []
         },
@@ -912,6 +933,13 @@
             "children": []
         },
         {
+            "id": "Requirement 5.1.5",
+            "machine_id": "requirement_5_1_5",
+            "content": "`PROVIDER_ERROR` events SHOULD populate the `provider event details`'s `error code` field.",
+            "RFC 2119 keyword": "SHOULD",
+            "children": []
+        },
+        {
             "id": "Requirement 5.2.1",
             "machine_id": "requirement_5_2_1",
             "content": "The `client` MUST provide a function for associating `handler functions` with a particular `provider event type`.",
@@ -990,7 +1018,7 @@
                 {
                     "id": "Conditional Requirement 5.3.4.1",
                     "machine_id": "conditional_requirement_5_3_4_1",
-                    "content": "While the provider's `on context changed` function is executing, associated `PROVIDER_CONTEXT_PENDING` handlers MUST run.",
+                    "content": "While the provider's `on context changed` function is executing, associated `RECONCILING` handlers MUST run.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 },

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -428,12 +428,12 @@ stateDiagram-v2
     READY --> RECONCILING:::client:setContext()
     RECONCILING:::client --> READY:*
 
-    classDef client fill:#555
+    classDef client fill:#888
 ```
 
 \* transitions occurring when associated events are spontaneously emitted from the provider
 
-<span style="color:#555">█</span> only defined in static-context (client-side) paradigm
+<span style="color:#888">█</span> only defined in static-context (client-side) paradigm
 
 > [!NOTE]
 > Only SDKs implementing the [static context (client-side) paradigm](../glossary.md#static-context-paradigm) define `RECONCILING` to facilitate [context reconciliation](./02-providers.md#26-provider-context-reconciliation).

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -450,7 +450,7 @@ see: [static-context paradigm](../glossary.md#static-context-paradigm)
 
 > In addition to `NOT_READY`, `READY`, `STALE`, or `ERROR`, the  `provider status` accessor must support possible value `CONTEXT_PENDING`.
 
-In the static context paradigm, the implementation must define a `provider status` indicating that a provider is reconciling its internal state with a context change.
+In the static context paradigm, the implementation must define a `provider status` indicating that a provider is reconciling its internal state due to a context change.
 
 #### Requirement 1.7.3
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -501,4 +501,4 @@ see: [error codes](https://openfeature.dev/specification/types#error-code), [fla
 
 The SDK ensures that if the provider's lifecycle methods terminate with an `error code`, that error code is included in any associated error events and returned/thrown errors/exceptions.
 
-see: [error codes](https://openfeature.dev/specification/types#error-code)
+see: [error codes](../types#error-code)

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -435,7 +435,8 @@ stateDiagram-v2
 
 <span style="color:#555">█</span> only defined in static-context (client-side) paradigm
 
-Note that only SDKs implementing the [static context (client-side) paradigm](../glossary.md#static-context-paradigm) define `RECONCILING` to facilitate [context reconciliation](./02-providers.md#26-provider-context-reconciliation).
+> [!NOTE]
+> Only SDKs implementing the [static context (client-side) paradigm](../glossary.md#static-context-paradigm) define `RECONCILING` to facilitate [context reconciliation](./02-providers.md#26-provider-context-reconciliation).
 
 #### Requirement 1.7.1
 
@@ -493,7 +494,7 @@ see: [error codes](../types.md#error-code), [flag value resolution](./02-provide
 TThe client defaults and returns the `PROVIDER_FATAL` `error code` if evaluation is attempted after the provider has transitioned to an irrecoverable error state.
 The SDK avoids calling the provider's resolver functions entirely ("short-circuits") if the provider is in this state.
 
-see: [error codes](../types#error-code), [flag value resolution](./02-providers.md#22-flag-value-resolution)
+see: [error codes](../types.md#error-code), [flag value resolution](./02-providers.md#22-flag-value-resolution)
 
 #### Requirement 1.7.8
 
@@ -501,4 +502,4 @@ see: [error codes](../types#error-code), [flag value resolution](./02-providers.
 
 The SDK ensures that if the provider's lifecycle methods terminate with an `error code`, that error code is included in any associated error events and returned/thrown errors/exceptions.
 
-see: [error codes](../types#error-code)
+see: [error codes](../types.md#error-code)

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -491,7 +491,7 @@ see: [error codes](../types.md#error-code), [flag value resolution](./02-provide
 
 > The client **SHOULD** default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `PROVIDER_FATAL`.
 
-TThe client defaults and returns the `PROVIDER_FATAL` `error code` if evaluation is attempted after the provider has transitioned to an irrecoverable error state.
+The client defaults and returns the `PROVIDER_FATAL` `error code` if evaluation is attempted after the provider has transitioned to an irrecoverable error state.
 The SDK avoids calling the provider's resolver functions entirely ("short-circuits") if the provider is in this state.
 
 see: [error codes](../types.md#error-code), [flag value resolution](./02-providers.md#22-flag-value-resolution)

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -410,27 +410,28 @@ This state of the provider is exposed on associated `clients`.
 The diagram below illustrates the possible states and transitions of the `state` field for a provider during the provider lifecycle.
 
 ```mermaid
----
-title: Provider State
----
 stateDiagram-v2
     direction LR
     [*] --> NOT_READY
     NOT_READY --> READY:initialize()
     NOT_READY --> ERROR:initialize()
-    READY --> ERROR*
-    ERROR --> READY*
-    READY --> STALE*
-    STALE --> READY*
-    STALE --> ERROR*
+    READY --> ERROR:*
+    ERROR --> READY:*
+    READY --> STALE:*
+    STALE --> READY:*
+    STALE --> ERROR:*
     READY --> NOT_READY:shutdown()
     STALE --> NOT_READY:shutdown()
     ERROR --> NOT_READY:shutdown()
+    READY --> CONTEXT_PENDING:::optional:setContext()
+    CONTEXT_PENDING --> READY:*
+
+    classDef optional fill:#999
 ```
 
 \* transitions occurring when associated events are spontaneously emitted from the provider
 
-Note that SDKs implementing the [static context (client-side) paradigm](../glossary.md#static-context-paradigm) define additional states to facilitate [context reconciliation](./02-providers.md#26-provider-context-reconciliation).
+Note that only SDKs implementing the [static context (client-side) paradigm](../glossary.md#static-context-paradigm) define `CONTEXT_PENDING` to facilitate [context reconciliation](./02-providers.md#26-provider-context-reconciliation).
 
 #### Requirement 1.7.1
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -480,7 +480,7 @@ If the provider has failed to initialize, the `provider status` should indicate 
 
 #### Requirement 1.7.6
 
-> The client **SHOULD** default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `NOT_READY`.
+> The client **MUST** default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `NOT_READY`.
 
 The client defaults and returns the `PROVIDER_NOT_READY` `error code` if evaluation is attempted before the provider is initialized (the provider is still in a `NOT_READY` state).
 The SDK avoids calling the provider's resolver functions entirely ("short-circuits") if the provider is in this state.
@@ -489,7 +489,7 @@ see: [error codes](../types.md#error-code), [flag value resolution](./02-provide
 
 #### Requirement 1.7.7
 
-> The client **SHOULD** default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `PROVIDER_FATAL`.
+> The client **MUST** default, run error hooks, and indicate an error if flag resolution is attempted while the provider is in `PROVIDER_FATAL`.
 
 The client defaults and returns the `PROVIDER_FATAL` `error code` if evaluation is attempted after the provider has transitioned to an irrecoverable error state.
 The SDK avoids calling the provider's resolver functions entirely ("short-circuits") if the provider is in this state.

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -493,7 +493,7 @@ see: [error codes](https://openfeature.dev/specification/types#error-code), [fla
 TThe client defaults and returns the `PROVIDER_FATAL` `error code` if evaluation is attempted after the provider has transitioned to an irrecoverable error state.
 The SDK avoids calling the provider's resolver functions entirely ("short-circuits") if the provider is in this state.
 
-see: [error codes](https://openfeature.dev/specification/types#error-code), [flag value resolution](./02-providers.md#22-flag-value-resolution)
+see: [error codes](../types#error-code), [flag value resolution](./02-providers.md#22-flag-value-resolution)
 
 #### Requirement 1.7.8
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -410,6 +410,9 @@ This state of the provider is exposed on associated `clients`.
 The diagram below illustrates the possible states and transitions of the `state` field for a provider during the provider lifecycle.
 
 ```mermaid
+---
+title: Provider lifecycle
+---
 stateDiagram-v2
     direction LR
     [*] --> NOT_READY

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -468,6 +468,6 @@ If the provider has failed to initialize, the `provider status` should indicate 
 
 > The client **SHOULD** indicate an error if flag resolution is attempted before the provider is ready.
 
-The SDK should return an informative `error code`, such as `PROVIDER_NOT_READY` if evaluation in attempted before the provider is initialized (the provider is still in a `NOT_READY` state).
+The SDK should return an informative `error code`, such as `PROVIDER_NOT_READY`, if evaluation is attempted before the provider is initialized (the provider is still in a `NOT_READY` state).
 
 see: [error codes](https://openfeature.dev/specification/types#error-code)

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -484,7 +484,7 @@ If the provider has failed to initialize, the `provider status` should indicate 
 The client defaults and returns the `PROVIDER_NOT_READY` `error code` if evaluation is attempted before the provider is initialized (the provider is still in a `NOT_READY` state).
 The SDK avoids calling the provider's resolver functions entirely ("short-circuits") if the provider is in this state.
 
-see: [error codes](https://openfeature.dev/specification/types#error-code), [flag value resolution](./02-providers.md#22-flag-value-resolution)
+see: [error codes](../types.md#error-code), [flag value resolution](./02-providers.md#22-flag-value-resolution)
 
 #### Requirement 1.7.7
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -426,7 +426,8 @@ stateDiagram-v2
     STALE --> NOT_READY:shutdown()
     ERROR --> NOT_READY:shutdown()
     READY --> RECONCILING:::client:setContext()
-    RECONCILING:::client --> READY:*
+    RECONCILING:::client --> READY
+    RECONCILING:::client --> ERROR
 
     classDef client fill:#888
 ```

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -197,7 +197,7 @@ class MyProvider implements Provider {
 > If the provider's `initialize` function fails to render the provider ready to evaluate flags, it **SHOULD** abnormally terminate.
 
 If a provider is unable to start up correctly, it should indicate abnormal execution by throwing an exception, returning an error, or otherwise indicating so by means idiomatic to the implementation language.
-If the error is irrecoverable (perhaps due to bad credentials or invalid configuration) you can use the `PROVIDER_FATAL` error code.
+If the error is irrecoverable (perhaps due to bad credentials or invalid configuration) the `PROVIDER_FATAL` error code should be used.
 
 see: [error codes](../types.md#error-code)
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -197,7 +197,7 @@ class MyProvider implements Provider {
 > If the provider's `initialize` function fails to render the provider ready to evaluate flags, it **SHOULD** abnormally terminate.
 
 If a provider is unable to start up correctly, it should indicate abnormal execution by throwing an exception, returning an error, or otherwise indicating so by means idiomatic to the implementation language.
-If the error is irrecoverable (perhaps due to bad credentials or invalid configuration) you can use the `PROVIDER_STATE_FATAL` error code.
+If the error is irrecoverable (perhaps due to bad credentials or invalid configuration) you can use the `PROVIDER_FATAL` error code.
 
 see: [error codes](../types.md#error-code)
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -188,53 +188,15 @@ class MyProvider implements Provider {
 }
 ```
 
-#### Requirement 2.4.2
+#### Condition 2.4.2
 
-> The `provider` **MAY** define a `status` field/accessor which indicates the readiness of the provider, with possible values `NOT_READY`, `READY`, `STALE`, or `ERROR`.
+> The provider defines an `initialize` function.
 
-Providers without this field can be assumed to be ready immediately.
+##### Conditional Requirement 2.4.2.1
 
-The diagram below illustrates the possible states and transitions of the `status` fields.
+> If the provider's `initialize` function fails to ready the provider to evaluate flags, it **MUST** abnormally terminate.
 
-```mermaid
----
-title: Provider State
----
-stateDiagram-v2
-    direction LR
-    [*] --> NOT_READY
-    NOT_READY --> READY:initialize
-    READY --> ERROR
-    ERROR --> READY
-    READY --> STALE
-    STALE --> READY
-    STALE --> ERROR
-    READY --> NOT_READY:shutdown
-    STALE --> NOT_READY:shutdown
-    ERROR --> NOT_READY:shutdown
-```
-
-see [provider status](../types.md#provider-status)
-
-#### Requirement 2.4.3
-
-> The provider **MUST** set its `status` field/accessor to `READY` if its `initialize` function terminates normally.
-
-If the provider supports the `status` field/accessor and initialization succeeds, setting the `status` to `READY` indicates that the provider is initialized and flag evaluation is proceeding normally.
-
-#### Requirement 2.4.4
-
-> The provider **MUST** set its `status` field to `ERROR` if its `initialize` function terminates abnormally.
-
-If the provider supports the `status` field/accessor and initialization fails, setting the `status` to `ERROR` indicates the provider is in an error state. If the error is transient in nature (ex: a connectivity failure of some kind) the provider can attempt to resolve this state automatically.
-
-#### Requirement 2.4.5
-
-> The provider **SHOULD** indicate an error if flag resolution is attempted before the provider is ready.
-
-It's recommended to set an informative `error code`, such as `PROVIDER_NOT_READY` if evaluation in attempted before the provider is initialized.
-
-see: [error codes](https://openfeature.dev/specification/types#error-code)
+If a provider is unable to start up correctly, it should indicate abnormal execution by throwing an exception, returning an error, or otherwise indicating so by means idiomatic to the implementation language.
 
 ### 2.5. Shutdown
 
@@ -266,14 +228,14 @@ see: [initialization](#24-initialization)
 
 [![experimental](https://img.shields.io/static/v1?label=Status&message=experimental&color=orange)](https://github.com/open-feature/spec/tree/main/specification#experimental)
 
-Static-context focused providers may need a mechanism to understand when their cache of evaluated flags must be invalidated or updated. An `on context changed` handler can be defined which performs whatever operations are needed to reconcile the evaluated flags with the new context.
+Static-context focused providers may need a mechanism to understand when their cache of evaluated flags must be invalidated or updated. An `on context changed` function can be defined which performs whatever operations are needed to reconcile the evaluated flags with the new context.
 
 #### Requirement 2.6.1
 
-> The provider **MAY** define an `on context changed` handler, which takes an argument for the previous context and the newly set context, in order to respond to an evaluation context change.
+> The provider **MAY** define an `on context changed` function, which takes an argument for the previous context and the newly set context, in order to respond to an evaluation context change.
 
 Especially in static-context implementations, providers and underlying SDKs may maintain state for a particular context.
-The `on context changed` handler provides a mechanism to update this state, often by re-evaluating flags in bulk with respect to the new context.
+The `on context changed` function provides a mechanism to update this state, often by re-evaluating flags in bulk with respect to the new context.
 
 ```java
 // MyProvider implementation of the onContextChanged function defined in Provider

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -194,9 +194,12 @@ class MyProvider implements Provider {
 
 ##### Conditional Requirement 2.4.2.1
 
-> If the provider's `initialize` function fails to ready the provider to evaluate flags, it **MUST** abnormally terminate.
+> If the provider's `initialize` function fails to render the provider ready to evaluate flags, it **SHOULD** abnormally terminate.
 
 If a provider is unable to start up correctly, it should indicate abnormal execution by throwing an exception, returning an error, or otherwise indicating so by means idiomatic to the implementation language.
+If the error is irrecoverable (perhaps due to bad credentials or invalid configuration) you can use the `PROVIDER_STATE_FATAL` error code.
+
+see: [error codes](../types.md#error-code)
 
 ### 2.5. Shutdown
 

--- a/specification/sections/03-evaluation-context.md
+++ b/specification/sections/03-evaluation-context.md
@@ -124,15 +124,15 @@ see: [static-context paradigm](../glossary.md#static-context-paradigm)
 
 ##### Conditional Requirement 3.2.4.1
 
-> When the global `evaluation context` is set, the `on context changed` handler **MUST** run.
+> When the global `evaluation context` is set, the `on context changed` function **MUST** run.
 
-The SDK implementation must run the `on context changed` handler on all registered provider that use the global `evaluation context` whenever it is mutated.
+The SDK implementation must run the `on context changed` function on all registered provider that use the global `evaluation context` whenever it is mutated.
 
 ##### Conditional Requirement 3.2.4.2
 
-> When the `evaluation context` for a specific provider is set, the `on context changed` handler **MUST** only run on the associated provider.
+> When the `evaluation context` for a specific provider is set, the `on context changed` function **MUST** only run on the associated provider.
 
-The SDK implementation must run the `on context changed` handler only on the provider that is scoped to the mutated `evaluation context`.
+The SDK implementation must run the `on context changed` function only on the provider that is scoped to the mutated `evaluation context`.
 
 ### 3.3 Context Propagation
 

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -197,7 +197,7 @@ see: [static-context paradigm](../glossary.md#static-context-paradigm)
 The implementation must run any `RECONCILING` handlers associated with the provider while the provider is reconciling its state.
 In languages with asynchronous semantics, the emission of this event can be skipped if the `on context changed` function of the provider in question executes synchronously for a given provider, no other operations can take place while it runs.
 
-see: [provider event types](../types.md#provider-events), [provider events](#51-provider-events), context, [provider context reconciliation](02-providers.md#26-provider-context-reconciliation)
+see: [provider event types](../types.md#provider-events), [provider events](#51-provider-events), [provider context reconciliation](02-providers.md#26-provider-context-reconciliation)
 
 ##### Conditional Requirement 5.3.4.2
 
@@ -206,7 +206,7 @@ see: [provider event types](../types.md#provider-events), [provider events](#51-
 The implementation must run any `PROVIDER_CONTEXT_CHANGED` handlers associated with the provider after the provider has reconciled its state and returned from the `on context changed` function.
 The `PROVIDER_CONTEXT_CHANGED` is not emitted from the provider itself; the SDK implementation must run the `PROVIDER_CONTEXT_CHANGED` handlers if the `on context changed` function terminates normally.
 
-see: [provider event types](../types.md#provider-events), [provider events](#51-provider-events), context, [provider context reconciliation](02-providers.md#26-provider-context-reconciliation)
+see: [provider event types](../types.md#provider-events), [provider events](#51-provider-events), [provider context reconciliation](02-providers.md#26-provider-context-reconciliation)
 
 ##### Conditional Requirement 5.3.4.3
 
@@ -214,7 +214,7 @@ see: [provider event types](../types.md#provider-events), [provider events](#51-
 
 The `PROVIDER_ERROR` is not emitted from the provider itself; the SDK implementation must run the `PROVIDER_ERROR` handlers if the `on context changed` throws or otherwise signals an error.
 
-see: [provider event types](../types.md#provider-events), [provider events](#51-provider-events), context, [provider context reconciliation](02-providers.md#26-provider-context-reconciliation)
+see: [provider event types](../types.md#provider-events), [provider events](#51-provider-events), [provider context reconciliation](02-providers.md#26-provider-context-reconciliation)
 
 #### Requirement 5.3.5
 

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -228,7 +228,7 @@ The SDK must update it's internal representation of the provider's state accordi
 | `PROVIDER_READY`                 | `READY`                                                 |
 | `PROVIDER_STALE`                 | `STALE`                                                 |
 | `PROVIDER_ERROR`                 | `ERROR`                                                 |
-| `PROVIDER_CONFIGURATION_CHANGED` | N/A (provider remains in state `READY`)                 |
+| `PROVIDER_CONFIGURATION_CHANGED` | N/A (provider remains in its current state)                 |
 | `PROVIDER_CONTEXT_CHANGED`       | N/A (only emitted by SDK during context reconciliation) |
 | `PROVIDER_RECONCILING`           | N/A (only emitted by SDK during context reconciliation) |
 

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -28,7 +28,7 @@ graph
 
 > The `provider` **MAY** define a mechanism for signaling the occurrence of one of a set of events, including `PROVIDER_READY`, `PROVIDER_ERROR`, `PROVIDER_CONFIGURATION_CHANGED` and `PROVIDER_STALE`, with a `provider event details` payload. 
 
-Providers cannot emit `PROVIDER_CONTEXT_CHANGED` or `RECONCILING` event.
+Providers cannot emit `PROVIDER_CONTEXT_CHANGED` or `PROVIDER_RECONCILING` event.
 These are emitted only by the SDK during context reconciliation.
 
 If available, native event-emitter or observable/observer language constructs can be used.

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -156,7 +156,7 @@ See [provider initialization](./02-providers.md#24-initialization), [setting a p
 ### Event handlers and context reconciliation
 
 Providers built to conform to the static context paradigm feature two additional events: `PROVIDER_CONTEXT_CHANGE_PENDING` and `PROVIDER_CONTEXT_CHANGED`.
-While the provider is reconciling it's internal state (the `on context changed` function is running and not yet terminated) the SDK emits `PROVIDER_CONTEXT_CHANGE_PENDING` and transitions the provider into state `CONTEXT_PENDING`.
+While the provider is reconciling its internal state (the `on context changed` function is running and not yet terminated), the SDK emits `PROVIDER_CONTEXT_CHANGE_PENDING` and transitions the provider into state `CONTEXT_PENDING`.
 This can be particularly useful for displaying loading indicators while the [evaluation context](./03-evaluation-context.md) is being reconciled.
 
 If the `on context changed` function terminates normally, the SDK emits (`PROVIDER_CONTEXT_CHANGED`) and transitions the provider into the `READY` state, otherwise it emits `PROVIDER_ERROR` and transitions the provider into `ERROR` state.

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -28,9 +28,16 @@ graph
 
 > The `provider` **MAY** define a mechanism for signaling the occurrence of one of a set of events, including `PROVIDER_READY`, `PROVIDER_ERROR`, `PROVIDER_CONFIGURATION_CHANGED` and `PROVIDER_STALE`, with a `provider event details` payload. 
 
+Providers cannot emit `PROVIDER_CONTEXT_CHANGED` or `PROVIDER_CONTEXT_PENDING` event. These are emitted only by the SDK during context reconciliation.
+
 If available, native event-emitter or observable/observer language constructs can be used.
 
-see: [provider event types](../types.md#provider-events), [`event details`](../types.md#provider-event-details).
+When a provider is unable to evaluate flags (perhaps due to loss of connection with a remote service) the provider can signal this by emitting a `PROVIDER_ERROR` event.
+If the error state is irrecoverable, the `PROVIDER_STATE_FATAL` error code can be used.
+When it recovers, it can emit a `PROVIDER_READY` event.
+If a provider caches rules-sets or previously evaluated flags, and such states cannot be considered up-to-date, the provider can signal this by emitting a `PROVIDER_STALE` event.
+
+see: [provider event types](../types.md#provider-events), [`event details`](../types.md#provider-event-details), [events handlers and context reconciliation](#event-handlers-and-context-reconciliation)
 
 #### Requirement 5.1.2
 
@@ -147,10 +154,13 @@ See [provider initialization](./02-providers.md#24-initialization), [setting a p
 
 ### Event handlers and context reconciliation
 
-Providers built to conform to the static context paradigm feature an additional `PROVIDER_CONTEXT_CHANGED` event, which is used to signal that the global context has been changed, and flags should be re-evaluated.
+Providers built to conform to the static context paradigm feature two additional events: `PROVIDER_CONTEXT_CHANGE_PENDING` and `PROVIDER_CONTEXT_CHANGED`.
+While the provider is reconciling it's internal state (the `on context changed` function is running and not yet terminated) the SDK emits `PROVIDER_CONTEXT_CHANGE_PENDING` and transitions the provider into state `CONTEXT_PENDING`.
+This can be particularly useful for displaying loading indicators while the [evaluation context](./03-evaluation-context.md) is being reconciled.
+
+If the `on context changed` function terminates normally, the SDK emits (`PROVIDER_CONTEXT_CHANGED`) and transitions the provider into the `READY` state, otherwise it emits `PROVIDER_ERROR` and transitions the provider into `ERROR` state.
+The `PROVIDER_CONTEXT_CHANGED` is used to signal that the associated context has been changed, and flags should be re-evaluated.
 This can be particularly useful for triggering UI repaints in multiple components when one component updates the [evaluation context](./03-evaluation-context.md).
-SDK implementations automatically fire the the `PROVIDER_CONTEXT_CHANGED` events if the `on context changed` handler terminates normally (and `PROVIDER_ERROR` events otherwise).
-Optionally, some providers may transition to the `STALE` state while their associated context is waiting to be reconciled, since this may involve asynchronous operations such as network calls.
 
 ```mermaid
 ---
@@ -158,11 +168,11 @@ title: Provider context reconciliation
 ---
 stateDiagram-v2
     direction TB
-    READY --> READY:emit(PROVIDER_CONTEXT_CHANGED)
+    READY --> READY:emit(PROVIDER_CONFIGURATION_CHANGED)
+    READY --> ERROR:emit(PROVIDER_ERROR)
     ERROR --> READY:emit(PROVIDER_READY)
-    READY --> STALE:emit(PROVIDER_STALE)
-    STALE --> READY:emit(PROVIDER_CONTEXT_CHANGED)
-    STALE --> ERROR:emit(PROVIDER_ERROR)
+    READY --> CONTEXT_PENDING:emit(PROVIDER_CONTEXT_CHANGE_PENDING)
+    CONTEXT_PENDING --> READY:emit(PROVIDER_CONTEXT_CHANGED)
 ```
 
 #### Condition 5.3.4
@@ -175,10 +185,10 @@ see: [static-context paradigm](../glossary.md#static-context-paradigm)
 
 ##### Conditional Requirement 5.3.4.1
 
-> When the provider's `on context changed` is called, the provider **MAY** emit the `PROVIDER_STALE` event, and transition to the `STALE` state.
+> While the provider's `on context changed` function is executing, associated `PROVIDER_CONTEXT_PENDING` handlers **MUST** run.
 
-Some providers cache evaluated flags, and re-evaluate them when the context is changed.
-In these cases, the provider may signal its cache is invalid with the `PROVIDER_STALE` event and the `STALE` provider state.
+The implementation must run any `PROVIDER_CONTEXT_PENDING` handlers associated with the provider while the provider is reconciling its state.
+In languages with asynchronous semantics, the emission of this event can be skipped if the `on context changed` function of the provider in question executes synchronously for a given provider, no other operations can take place while it runs.
 
 see: [provider event types](../types.md#provider-events), [provider events](#51-provider-events), context, [provider context reconciliation](02-providers.md#26-provider-context-reconciliation)
 
@@ -198,3 +208,21 @@ see: [provider event types](../types.md#provider-events), [provider events](#51-
 The `PROVIDER_ERROR` is not emitted from the provider itself; the SDK implementation must run the `PROVIDER_ERROR` handlers if the `on context changed` throws or otherwise signals an error.
 
 see: [provider event types](../types.md#provider-events), [provider events](#51-provider-events), context, [provider context reconciliation](02-providers.md#26-provider-context-reconciliation)
+
+#### Requirement 5.3.5
+
+> If the provider emits an event, the value of the client's `provider status` **MUST** be updated accordingly.
+
+Some providers may emit events spontaneously, based on changes in their internal state (connections, caches, etc).
+The SDK must update it's internal representation of the provider's state accordingly:
+
+| Event                            | Associated Status                                                  |
+| -------------------------------- | ------------------------------------------------------------------ |
+| `PROVIDER_READY`                 | `READY`                                                            |
+| `PROVIDER_STALE`                 | `STALE`                                                            |
+| `PROVIDER_ERROR`                 | `ERROR`                                                            |
+| `PROVIDER_CONFIGURATION_CHANGED` | N/A (provider remains in state `READY`)                            |
+| `PROVIDER_CONTEXT_CHANGED`       | N/A (only emitted by SDK during context reconciliation) |
+| `PROVIDER_CONTEXT_PENDING`       | N/A (only emitted by SDK during context reconciliation) |
+
+see [provider lifecycle management](01-flag-evaluation.md#17-provider-lifecycle-management)

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -232,4 +232,4 @@ The SDK must update it's internal representation of the provider's state accordi
 | `PROVIDER_CONTEXT_CHANGED`       | N/A (only emitted by SDK during context reconciliation) |
 | `PROVIDER_RECONCILING`           | N/A (only emitted by SDK during context reconciliation) |
 
-see [provider lifecycle management](01-flag-evaluation.md#17-provider-lifecycle-management)
+see: [provider lifecycle management](01-flag-evaluation.md#17-provider-lifecycle-management)

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -202,18 +202,19 @@ see: [provider event types](../types.md#provider-events), [provider events](#51-
 
 ##### Conditional Requirement 5.3.4.2
 
-> If the provider's `on context changed` function terminates normally, associated `PROVIDER_CONTEXT_CHANGED` handlers **MUST** run.
+> If the provider's `on context changed` function terminates normally, and no other invocations have yet to terminate, associated `PROVIDER_CONTEXT_CHANGED` handlers **MUST** run.
 
 The implementation must run any `PROVIDER_CONTEXT_CHANGED` handlers associated with the provider after the provider has reconciled its state and returned from the `on context changed` function.
 The `PROVIDER_CONTEXT_CHANGED` is not emitted from the provider itself; the SDK implementation must run the `PROVIDER_CONTEXT_CHANGED` handlers if the `on context changed` function terminates normally.
-
+It's possible that the `on context changed` function is invoked simultaneously or in quick succession; in this case the SDK will only run the `PROVIDER_CONTEXT_CHANGED` handlers after all reentrant invocations have terminated, and the last to terminate was successful (terminated normally).
 see: [provider event types](../types.md#provider-events), [provider events](#51-provider-events), [provider context reconciliation](02-providers.md#26-provider-context-reconciliation)
 
 ##### Conditional Requirement 5.3.4.3
 
-> If the provider's `on context changed` function terminates abnormally, associated `PROVIDER_ERROR` handlers **MUST** run.
+> If the provider's `on context changed` function terminates abnormally, and no other invocations have yet to terminate, associated `PROVIDER_ERROR` handlers **MUST** run.
 
 The `PROVIDER_ERROR` is not emitted from the provider itself; the SDK implementation must run the `PROVIDER_ERROR` handlers if the `on context changed` throws or otherwise signals an error.
+It's possible that the `on context changed` function is invoked simultaneously or in quick succession; in this case the SDK will only run the `PROVIDER_ERROR` handlers after all reentrant invocations have terminated, and the last to terminate was unsuccessful (terminated abnormally).
 
 see: [provider event types](../types.md#provider-events), [provider events](#51-provider-events), [provider context reconciliation](02-providers.md#26-provider-context-reconciliation)
 

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -34,8 +34,8 @@ These are emitted only by the SDK during context reconciliation.
 If available, native event-emitter or observable/observer language constructs can be used.
 
 When a provider is unable to evaluate flags (perhaps due to loss of connection with a remote service) the provider can signal this by emitting a `PROVIDER_ERROR` event.
-If the error state is irrecoverable, the `PROVIDER_FATAL` error code can be used.
 When it recovers, it can emit a `PROVIDER_READY` event.
+If the error state is irrecoverable, the `PROVIDER_FATAL` error code can be used.
 If a provider caches rules-sets or previously evaluated flags, and such states cannot be considered up-to-date, the provider can signal this by emitting a `PROVIDER_STALE` event.
 
 see: [provider event types](../types.md#provider-events), [`event details`](../types.md#provider-event-details), [events handlers and context reconciliation](#event-handlers-and-context-reconciliation)

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -161,7 +161,7 @@ See [provider initialization](./02-providers.md#24-initialization), [setting a p
 
 ### Event handlers and context reconciliation
 
-Providers built to conform to the static context paradigm feature two additional events: `PROVIDER_CONTEXT_CHANGE_PENDING` and `PROVIDER_CONTEXT_CHANGED`.
+Providers built to conform to the static context paradigm feature two additional events: `PROVIDER_RECONCILING` and `PROVIDER_CONTEXT_CHANGED`.
 When the provider is reconciling its internal state (the `on context changed` function is running and not yet terminated), the SDK emits `PROVIDER_CONTEXT_CHANGE_PENDING` and transitions the provider into state `RECONCILING`.
 This can be particularly useful for displaying loading indicators while the [evaluation context](./03-evaluation-context.md) is being reconciled.
 

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -156,7 +156,7 @@ See [provider initialization](./02-providers.md#24-initialization), [setting a p
 ### Event handlers and context reconciliation
 
 Providers built to conform to the static context paradigm feature two additional events: `PROVIDER_CONTEXT_CHANGE_PENDING` and `PROVIDER_CONTEXT_CHANGED`.
-While the provider is reconciling its internal state (the `on context changed` function is running and not yet terminated), the SDK emits `PROVIDER_CONTEXT_CHANGE_PENDING` and transitions the provider into state `CONTEXT_PENDING`.
+When the provider is reconciling its internal state (the `on context changed` function is running and not yet terminated), the SDK emits `PROVIDER_CONTEXT_CHANGE_PENDING` and transitions the provider into state `CONTEXT_PENDING`.
 This can be particularly useful for displaying loading indicators while the [evaluation context](./03-evaluation-context.md) is being reconciled.
 
 If the `on context changed` function terminates normally, the SDK emits (`PROVIDER_CONTEXT_CHANGED`) and transitions the provider into the `READY` state, otherwise it emits `PROVIDER_ERROR` and transitions the provider into `ERROR` state.

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -162,7 +162,7 @@ See [provider initialization](./02-providers.md#24-initialization), [setting a p
 ### Event handlers and context reconciliation
 
 Providers built to conform to the static context paradigm feature two additional events: `PROVIDER_RECONCILING` and `PROVIDER_CONTEXT_CHANGED`.
-When the provider is reconciling its internal state (the `on context changed` function is running and not yet terminated), the SDK emits `PROVIDER_CONTEXT_CHANGE_PENDING` and transitions the provider into state `RECONCILING`.
+When the provider is reconciling its internal state (the `on context changed` function is running and not yet terminated), the SDK emits `PROVIDER_RECONCILING` and transitions the provider into state `RECONCILING`.
 This can be particularly useful for displaying loading indicators while the [evaluation context](./03-evaluation-context.md) is being reconciled.
 
 If the `on context changed` function terminates normally, the SDK emits (`PROVIDER_CONTEXT_CHANGED`) and transitions the provider into the `READY` state, otherwise it emits `PROVIDER_ERROR` and transitions the provider into `ERROR` state.
@@ -178,7 +178,7 @@ stateDiagram-v2
     READY --> READY:emit(PROVIDER_CONFIGURATION_CHANGED)
     READY --> ERROR:emit(PROVIDER_ERROR)
     ERROR --> READY:emit(PROVIDER_READY)
-    READY --> RECONCILING:emit(PROVIDER_CONTEXT_CHANGE_PENDING)
+    READY --> RECONCILING:emit(PROVIDER_RECONCILING)
     RECONCILING --> READY:emit(PROVIDER_CONTEXT_CHANGED)
 ```
 
@@ -228,7 +228,7 @@ The SDK must update it's internal representation of the provider's state accordi
 | `PROVIDER_READY`                 | `READY`                                                 |
 | `PROVIDER_STALE`                 | `STALE`                                                 |
 | `PROVIDER_ERROR`                 | `ERROR`                                                 |
-| `PROVIDER_CONFIGURATION_CHANGED` | N/A (provider remains in its current state)                 |
+| `PROVIDER_CONFIGURATION_CHANGED` | N/A (provider remains in its current state)             |
 | `PROVIDER_CONTEXT_CHANGED`       | N/A (only emitted by SDK during context reconciliation) |
 | `PROVIDER_RECONCILING`           | N/A (only emitted by SDK during context reconciliation) |
 

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -28,7 +28,8 @@ graph
 
 > The `provider` **MAY** define a mechanism for signaling the occurrence of one of a set of events, including `PROVIDER_READY`, `PROVIDER_ERROR`, `PROVIDER_CONFIGURATION_CHANGED` and `PROVIDER_STALE`, with a `provider event details` payload. 
 
-Providers cannot emit `PROVIDER_CONTEXT_CHANGED` or `PROVIDER_CONTEXT_PENDING` event. These are emitted only by the SDK during context reconciliation.
+Providers cannot emit `PROVIDER_CONTEXT_CHANGED` or `PROVIDER_CONTEXT_PENDING` event.
+These are emitted only by the SDK during context reconciliation.
 
 If available, native event-emitter or observable/observer language constructs can be used.
 

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -217,12 +217,12 @@ see: [provider event types](../types.md#provider-events), [provider events](#51-
 Some providers may emit events spontaneously, based on changes in their internal state (connections, caches, etc).
 The SDK must update it's internal representation of the provider's state accordingly:
 
-| Event                            | Associated Status                                                  |
-| -------------------------------- | ------------------------------------------------------------------ |
-| `PROVIDER_READY`                 | `READY`                                                            |
-| `PROVIDER_STALE`                 | `STALE`                                                            |
-| `PROVIDER_ERROR`                 | `ERROR`                                                            |
-| `PROVIDER_CONFIGURATION_CHANGED` | N/A (provider remains in state `READY`)                            |
+| Event                            | Associated Status                                       |
+| -------------------------------- | ------------------------------------------------------- |
+| `PROVIDER_READY`                 | `READY`                                                 |
+| `PROVIDER_STALE`                 | `STALE`                                                 |
+| `PROVIDER_ERROR`                 | `ERROR`                                                 |
+| `PROVIDER_CONFIGURATION_CHANGED` | N/A (provider remains in state `READY`)                 |
 | `PROVIDER_CONTEXT_CHANGED`       | N/A (only emitted by SDK during context reconciliation) |
 | `PROVIDER_CONTEXT_PENDING`       | N/A (only emitted by SDK during context reconciliation) |
 

--- a/specification/sections/05-events.md
+++ b/specification/sections/05-events.md
@@ -175,12 +175,13 @@ title: Provider context reconciliation
 ---
 stateDiagram-v2
     direction TB
-    READY --> READY:emit(PROVIDER_CONFIGURATION_CHANGED)
-    READY --> ERROR:emit(PROVIDER_ERROR)
-    ERROR --> READY:emit(PROVIDER_READY)
+    READY --> READY:emit(PROVIDER_CONTEXT_CHANGED)*
     READY --> RECONCILING:emit(PROVIDER_RECONCILING)
     RECONCILING --> READY:emit(PROVIDER_CONTEXT_CHANGED)
+    RECONCILING --> ERROR:emit(PROVIDER_ERROR)
 ```
+
+\* Implementations may allow for providers to reconcile synchronously, in which case no `PROVIDER_RECONCILING` event is emitted.
 
 #### Condition 5.3.4
 

--- a/specification/types.md
+++ b/specification/types.md
@@ -110,7 +110,7 @@ An enumerated error code represented idiomatically in the implementation languag
 | TYPE_MISMATCH         | The type of the flag value does not match the expected type.                                |
 | TARGETING_KEY_MISSING | The provider requires a targeting key and one was not provided in the `evaluation context`. |
 | INVALID_CONTEXT       | The `evaluation context` does not meet provider requirements.                               |
-| PROVIDER_STATE_FATAL  | The provider has entered a irrecoverable error state.                                       |
+| PROVIDER_STATE_FATAL  | The provider has entered an irrecoverable error state.                                      |
 | GENERAL               | The error was for a reason not enumerated above.                                            |
 
 ### Evaluation Options

--- a/specification/types.md
+++ b/specification/types.md
@@ -110,7 +110,7 @@ An enumerated error code represented idiomatically in the implementation languag
 | TYPE_MISMATCH         | The type of the flag value does not match the expected type.                                |
 | TARGETING_KEY_MISSING | The provider requires a targeting key and one was not provided in the `evaluation context`. |
 | INVALID_CONTEXT       | The `evaluation context` does not meet provider requirements.                               |
-| PROVIDER_STATE_FATAL  | The provider has entered an irrecoverable error state.                                      |
+| PROVIDER_FATAL        | The provider has entered an irrecoverable error state.                                      |
 | GENERAL               | The error was for a reason not enumerated above.                                            |
 
 ### Evaluation Options
@@ -129,13 +129,13 @@ This structure is populated by a provider for use by an [Application Author](./g
 
 An enumeration of possible provider states.
 
-| Status           | Explanation                                                                                        |
-| ---------------- | -------------------------------------------------------------------------------------------------- |
-| NOT_READY        | The provider has not been initialized.                                                             |
-| READY            | The provider has been initialized, and is able to reliably resolve flag values.                    |
-| ERROR            | The provider is initialized but is not able to reliably resolve flag values.                       |
-| STALE            | The provider's cached state is no longer valid and may not be up-to-date with the source of truth. |
-| CONTEXT_PENDING* | The provider is reconciling its state with a context change.                                       |
+| Status       | Explanation                                                                                        |
+| ------------ | -------------------------------------------------------------------------------------------------- |
+| NOT_READY    | The provider has not been initialized.                                                             |
+| READY        | The provider has been initialized, and is able to reliably resolve flag values.                    |
+| ERROR        | The provider is initialized but is not able to reliably resolve flag values.                       |
+| STALE        | The provider's cached state is no longer valid and may not be up-to-date with the source of truth. |
+| RECONCILING* | The provider is reconciling its state with a context change.                                       |
 
 \* [static context (client-side) paradigm](./glossary.md#static-context-paradigm) only
 
@@ -154,6 +154,7 @@ A structure defining an event payload, including:
 - provider name (string, required)
 - flags changed (string[], optional)
 - message (string, optional)
+- error code ([error code](#error-code), optional)
 - event metadata ([event metadata](#event-metadata))
 
 ### Event Metadata
@@ -171,7 +172,7 @@ An enumeration of provider events.
 | PROVIDER_ERROR                 | The provider signalled an error.                                                                                    |
 | PROVIDER_CONFIGURATION_CHANGED | A change was made to the backend flag configuration.                                                                |
 | PROVIDER_STALE                 | The provider's cached state is no longer valid and may not be up-to-date with the source of truth.                  |
-| PROVIDER_CONTEXT_PENDING*      | The context associated with the provider has changed, and the provider has not yet reconciled its associated state. |
+| PROVIDER_RECONCILING*          | The context associated with the provider has changed, and the provider has not yet reconciled its associated state. |
 | PROVIDER_CONTEXT_CHANGED*      | The context associated with the provider has changed, and the provider has reconciled its associated state.         |
 
 \* [static context (client-side) paradigm](./glossary.md#static-context-paradigm) only

--- a/specification/types.md
+++ b/specification/types.md
@@ -110,6 +110,7 @@ An enumerated error code represented idiomatically in the implementation languag
 | TYPE_MISMATCH         | The type of the flag value does not match the expected type.                                |
 | TARGETING_KEY_MISSING | The provider requires a targeting key and one was not provided in the `evaluation context`. |
 | INVALID_CONTEXT       | The `evaluation context` does not meet provider requirements.                               |
+| PROVIDER_STATE_FATAL  | The provider has entered a irrecoverable error state.                                       |
 | GENERAL               | The error was for a reason not enumerated above.                                            |
 
 ### Evaluation Options
@@ -128,12 +129,15 @@ This structure is populated by a provider for use by an [Application Author](./g
 
 An enumeration of possible provider states.
 
-| Status    | Explanation                                                                                         |
-| --------- | --------------------------------------------------------------------------------------------------- |
-| NOT_READY | The provider has not been initialized.                                                              |
-| READY     | The provider has been initialized, and is able to reliably resolve flag values.                     |
-| ERROR     | The provider is initialized but is not able to reliably resolve flag values.                        |
-| STALE     | The provider's cached state is no longer valid and may not be up-to-date with the source of truth.  |
+| Status           | Explanation                                                                                        |
+| ---------------- | -------------------------------------------------------------------------------------------------- |
+| NOT_READY        | The provider has not been initialized.                                                             |
+| READY            | The provider has been initialized, and is able to reliably resolve flag values.                    |
+| ERROR            | The provider is initialized but is not able to reliably resolve flag values.                       |
+| STALE            | The provider's cached state is no longer valid and may not be up-to-date with the source of truth. |
+| CONTEXT_PENDING* | The provider is reconciling its state with a context change.                                       |
+
+\* [static context (client-side) paradigm](./glossary.md#static-context-paradigm) only
 
 ### Provider Event Details
 
@@ -161,13 +165,14 @@ It supports definition of arbitrary properties, with keys of type `string`, and 
 
 An enumeration of provider events.
 
-| Event                          | Explanation                                                                                                  |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| PROVIDER_READY                 | The provider is ready to perform flag evaluations.                                                           |
-| PROVIDER_ERROR                 | The provider signalled an error.                                                                             |
-| PROVIDER_CONFIGURATION_CHANGED | A change was made to the backend flag configuration.                                                         |
-| PROVIDER_STALE                 | The provider's cached state is no longer valid and may not be up-to-date with the source of truth.           |
-| PROVIDER_CONTEXT_CHANGED*      | The context associated with the provider has changed, and the provider has reconciled it's associated state. |
+| Event                          | Explanation                                                                                                         |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| PROVIDER_READY                 | The provider is ready to perform flag evaluations.                                                                  |
+| PROVIDER_ERROR                 | The provider signalled an error.                                                                                    |
+| PROVIDER_CONFIGURATION_CHANGED | A change was made to the backend flag configuration.                                                                |
+| PROVIDER_STALE                 | The provider's cached state is no longer valid and may not be up-to-date with the source of truth.                  |
+| PROVIDER_CONTEXT_PENDING*      | The context associated with the provider has changed, and the provider has not yet reconciled its associated state. |
+| PROVIDER_CONTEXT_CHANGED*      | The context associated with the provider has changed, and the provider has reconciled its associated state.         |
 
 \* [static context (client-side) paradigm](./glossary.md#static-context-paradigm) only
 


### PR DESCRIPTION
* moves provider state into SDK (SDK now maintains provider state/lifecycle; provider interface is now "stateless")
* refine semantics around client state when context is pending/reconciled by using new events/states, instead of STALE
* add PROVIDER_FATAL error code

Resolves: https://github.com/open-feature/spec/issues/238

--- 

For background discussion, see https://github.com/open-feature/spec/issues/238

---

This should make provider authorship less error prone, and simpler. Providers essentially become stateless as far as the SDK is concerned. The provider is only obligated to optionally implement the `initialize`, `shutdown` and `onContextChange` functions and maintain is own private state (caches, connection, etc).

This also refines the semantics around context reconciliation, which is particularly important for client SDKs where providers need to reconcile their flags or ruleset(s) when context changes.

I believe these changes can all be implemented by SDKs in a non-breaking fashion.