### PR TITLE
fix: language-neutral verbiage for set-and-wait

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -31,7 +31,7 @@
         {
             "id": "Requirement 1.1.2.4",
             "machine_id": "requirement_1_1_2_4",
-            "content": "The `API` SHOULD provide functions to set a provider and wait for the `initialize` function to return or throw.",
+            "content": "The `API` SHOULD provide functions to set a provider and wait for the `initialize` function to complete or abnormally terminate.",
             "RFC 2119 keyword": "SHOULD",
             "children": []
         },

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -57,7 +57,7 @@ see [shutdown](./02-providers.md#25-shutdown), [setting a provider](#setting-a-p
 
 #### Requirement 1.1.2.4
 
-> The `API` **SHOULD** provide functions to set a provider and wait for the `initialize` function to return or throw.
+> The `API` **SHOULD** provide functions to set a provider and wait for the `initialize` function to complete or abnormally terminate.
 
 This function not only sets the provider, but ensures that the provider is ready (or in error) before returning or settling.
 
@@ -74,6 +74,7 @@ Client client = OpenFeatureAPI.getInstance().getClient('domain-1');
 ```
 
 Though it's possible to use [events](./05-events.md) to await provider readiness, such functions can make things simpler for `application authors` and `integrators`.
+Implementations indicate an error in a manner idiomatic to the language in use (returning an error, throwing and exception, etc).
 
 #### Requirement 1.1.3
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -74,7 +74,7 @@ Client client = OpenFeatureAPI.getInstance().getClient('domain-1');
 ```
 
 Though it's possible to use [events](./05-events.md) to await provider readiness, such functions can make things simpler for `application authors` and `integrators`.
-Implementations indicate an error in a manner idiomatic to the language in use (returning an error, throwing and exception, etc).
+Implementations indicate an error in a manner idiomatic to the language in use (returning an error, throwing an exception, etc).
 
 #### Requirement 1.1.3
 


### PR DESCRIPTION
Improving the language neutrality of this section (we usually use "abnormally terminate" not "throw", since many langs don't have "throw" semantics).