### PR TITLE
docs: add language-specific initialize naming

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -404,7 +404,7 @@
         {
             "id": "Requirement 2.4.1",
             "machine_id": "requirement_2_4_1",
-            "content": "The `provider` MAY define an `initialize` function which accepts the global `evaluation context` as an argument and performs initialization logic relevant to the provider.",
+            "content": "The `provider` MAY define an initialization function which accepts the global `evaluation context` as an argument and performs initialization logic relevant to the provider.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -121,7 +121,7 @@ ResolutionDetails<MyStruct> resolveStructureValue(string flagKey, MyStruct defau
 ```
 ##### Requirement 2.2.9
 
-> The `provider` **SHOULD** populate the `resolution details` structure's `flag metadata` field. 
+> The `provider` **SHOULD** populate the `resolution details` structure's `flag metadata` field.
 
 ##### Requirement 2.2.10
 
@@ -164,12 +164,11 @@ class MyProvider implements Provider {
 
 #### Requirement 2.4.1
 
-> The `provider` **MAY** define an `initialize` function which accepts the global `evaluation context` as an argument and performs initialization logic relevant to the provider.
+> The `provider` **MAY** define an initialization function which accepts the global `evaluation context` as an argument and performs initialization logic relevant to the provider.
 
 Many feature flag frameworks or SDKs require some initialization before they can be used.
 They might require the completion of an HTTP request, establishing persistent connections, or starting timers or worker threads.
-The `initialize` function is an ideal place for such logic.
-The `initialize` function is named in accordance with language idioms.
+The initialization function is an ideal place for such logic.
 
 ```java
 // MyProvider implementation of the initialize function defined in Provider
@@ -282,7 +281,7 @@ class MyProvider implements Provider {
   //...
 
   onContextChanged(EvaluationContext oldContext, EvaluationContext newContext): void {
-    // update context-sensitive cached flags, or otherwise react to the change in the global context 
+    // update context-sensitive cached flags, or otherwise react to the change in the global context
   }
 
   //...

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -168,7 +168,7 @@ class MyProvider implements Provider {
 
 Many feature flag frameworks or SDKs require some initialization before they can be used.
 They might require the completion of an HTTP request, establishing persistent connections, or starting timers or worker threads.
-The `initialization` function is an ideal place for such logic.
+The `initialize` function is an ideal place for such logic. The `initialize` function may be renamed in accordance with language idioms.
 
 ```java
 // MyProvider implementation of the initialize function defined in Provider

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -168,7 +168,8 @@ class MyProvider implements Provider {
 
 Many feature flag frameworks or SDKs require some initialization before they can be used.
 They might require the completion of an HTTP request, establishing persistent connections, or starting timers or worker threads.
-The `initialize` function is an ideal place for such logic. The `initialize` function may be renamed in accordance with language idioms.
+The `initialize` function is an ideal place for such logic.
+The `initialize` function is named in accordance with language idioms.
 
 ```java
 // MyProvider implementation of the initialize function defined in Provider


### PR DESCRIPTION
## This PR

Adds callout for language-specific `initialize` function naming. This is an idea @toddbaert had in [this review](https://github.com/open-feature/ruby-sdk/pull/78#discussion_r1480335799).