### PR TITLE
feat: adds allFlagMetadata to clients and provider interface

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -87,7 +87,7 @@
         {
             "id": "Requirement 1.2.3",
             "machine_id": "requirement_1_2_3",
-            "content": "The client interface MUST define a `all flag metadata` member or accessor, returning a collection of flag metadata from the provider.",
+            "content": "The client interface MUST define a `all flag metadata` member or accessor, containing a `flags` field or accessor which is a collection of flag metadata, from the provider.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -368,7 +368,7 @@
         {
             "id": "Requirement 2.1.2",
             "machine_id": "requirement_2_1_2",
-            "content": "The provider MAY define an `all flag metadata` field or accessor of type collection of flag_metadata, which identifies all available flag keys in the provider.",
+            "content": "The provider MAY define an `all flag metadata` field or accessor, containing a `flags` field or accessor which is a collection of flag metadata, identifying all available flag keys in the provider.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -85,6 +85,13 @@
             "children": []
         },
         {
+            "id": "Requirement 1.2.3",
+            "machine_id": "requirement_1_2_3",
+            "content": "The client interface MUST define a `allFlagMetadata` member or accessor, returning a collection of flag metadata from the provider.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
             "id": "Condition 1.3.1",
             "machine_id": "condition_1_3_1",
             "content": "The implementation uses the dynamic-context paradigm.",
@@ -361,7 +368,7 @@
         {
             "id": "Requirement 2.1.2",
             "machine_id": "requirement_2_1_2",
-            "content": "The provider `metadata` member or accessor MAY define an `allFlagMetadata` field or accessor of type collection of [flag_metadata](../types.md",
+            "content": "The provider MAY define an `allFlagMetadata` field or accessor of type collection of [flag_metadata](../types.md",
             "RFC 2119 keyword": "MAY",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -359,6 +359,28 @@
             "children": []
         },
         {
+            "id": "Requirement 2.1.2",
+            "machine_id": "requirement_2_1_2",
+            "content": "The provider `metadata` member or accessor MAY define an `allFlagKeys` field or accessor of type collection of strings, which identifies all available flag keys in the provider.",
+            "RFC 2119 keyword": "MAY",
+            "children": []
+        },
+        {
+            "id": "Condition 2.1.3",
+            "machine_id": "condition_2_1_3",
+            "content": "The implementing language has an asynchronous support.",
+            "RFC 2119 keyword": null,
+            "children": [
+                {
+                    "id": "Conditional Requirement 2.1.3.1",
+                    "machine_id": "conditional_requirement_2_1_3_1",
+                    "content": "The accessor for `allFlagKeys` SHOULD be asynchronous.",
+                    "RFC 2119 keyword": "SHOULD",
+                    "children": []
+                }
+            ]
+        },
+        {
             "id": "Requirement 2.2.1",
             "machine_id": "requirement_2_2_1",
             "content": "The `feature provider` interface MUST define methods to resolve flag values, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required) and `evaluation context` (optional), which returns a `resolution details` structure.",

--- a/specification.json
+++ b/specification.json
@@ -373,21 +373,6 @@
             "children": []
         },
         {
-            "id": "Condition 2.1.3",
-            "machine_id": "condition_2_1_3",
-            "content": "The implementing language has an asynchronous support.",
-            "RFC 2119 keyword": null,
-            "children": [
-                {
-                    "id": "Conditional Requirement 2.1.3.1",
-                    "machine_id": "conditional_requirement_2_1_3_1",
-                    "content": "The accessor for `allFlagMetadata` SHOULD be asynchronous.",
-                    "RFC 2119 keyword": "SHOULD",
-                    "children": []
-                }
-            ]
-        },
-        {
             "id": "Requirement 2.2.1",
             "machine_id": "requirement_2_2_1",
             "content": "The `feature provider` interface MUST define methods to resolve flag values, with parameters `flag key` (string, required), `default value` (boolean | number | string | structure, required) and `evaluation context` (optional), which returns a `resolution details` structure.",

--- a/specification.json
+++ b/specification.json
@@ -368,7 +368,7 @@
         {
             "id": "Requirement 2.1.2",
             "machine_id": "requirement_2_1_2",
-            "content": "The provider MAY define an `allFlagMetadata` field or accessor of type collection of [flag_metadata](../types.md",
+            "content": "The provider MAY define an `allFlagMetadata` field or accessor of type collection of flag_metadata, which identifies all available flag keys in the provider.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -361,7 +361,7 @@
         {
             "id": "Requirement 2.1.2",
             "machine_id": "requirement_2_1_2",
-            "content": "The provider `metadata` member or accessor MAY define an `allFlagKeys` field or accessor of type collection of strings, which identifies all available flag keys in the provider.",
+            "content": "The provider `metadata` member or accessor MAY define an `allFlagMetadata` field or accessor of type collection of [flag_metadata](../types.md",
             "RFC 2119 keyword": "MAY",
             "children": []
         },
@@ -374,7 +374,7 @@
                 {
                     "id": "Conditional Requirement 2.1.3.1",
                     "machine_id": "conditional_requirement_2_1_3_1",
-                    "content": "The accessor for `allFlagKeys` SHOULD be asynchronous.",
+                    "content": "The accessor for `allFlagMetadata` SHOULD be asynchronous.",
                     "RFC 2119 keyword": "SHOULD",
                     "children": []
                 }

--- a/specification.json
+++ b/specification.json
@@ -87,7 +87,7 @@
         {
             "id": "Requirement 1.2.3",
             "machine_id": "requirement_1_2_3",
-            "content": "The client interface MUST define a `allFlagMetadata` member or accessor, returning a collection of flag metadata from the provider.",
+            "content": "The client interface MUST define a `all flag metadata` member or accessor, returning a collection of flag metadata from the provider.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -368,7 +368,7 @@
         {
             "id": "Requirement 2.1.2",
             "machine_id": "requirement_2_1_2",
-            "content": "The provider MAY define an `allFlagMetadata` field or accessor of type collection of flag_metadata, which identifies all available flag keys in the provider.",
+            "content": "The provider MAY define an `all flag metadata` field or accessor of type collection of flag_metadata, which identifies all available flag keys in the provider.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -65,7 +65,7 @@ This function not only sets the provider, but ensures that the provider is ready
 // default provider
 OpenFeatureAPI.getInstance().setProviderAndWait(myprovider); // this method blocks until the provider is ready or in error
 // client uses the default provider
-Client client = OpenFeatureAPI.getInstance().getClient(); 
+Client client = OpenFeatureAPI.getInstance().getClient();
 
 // provider associated with domain-1
 OpenFeatureAPI.getInstance().setProviderAndWait('domain-1', myprovider); // this method blocks until the provider is ready or in error
@@ -170,6 +170,16 @@ client.getMetadata().getDomain(); // "domain-1"
 
 In previous drafts, this property was called `name`.
 For backwards compatibility, implementations should consider `name` an alias to `domain`.
+
+#### Requirement 1.2.3
+
+> The client interface **MUST** define a `allFlagMetadata` member or accessor, returning a collection of flag metadata from the provider.
+
+```typescript
+client.getAllFlagMetadata() // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]
+```
+
+This may return an empty collection if the provider does not implement the `allFlagMetadata` member or accessor.
 
 ### 1.3. Flag Evaluation
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -179,7 +179,7 @@ For backwards compatibility, implementations should consider `name` an alias to 
 client.getAllFlagMetadata() // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]
 ```
 
-This may return an empty collection if the provider does not implement the `allFlagMetadata` member or accessor.
+This may return a language-idiomatic way of describing the absence of a value if the provider does not implement the `allFlagMetadata` member or accessor.
 
 ### 1.3. Flag Evaluation
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -173,7 +173,7 @@ For backwards compatibility, implementations should consider `name` an alias to 
 
 #### Requirement 1.2.3
 
-> The client interface **MUST** define a `allFlagMetadata` member or accessor, returning a collection of flag metadata from the provider.
+> The client interface **MUST** define a `all flag metadata` member or accessor, returning a collection of flag metadata from the provider.
 
 ```typescript
 client.getAllFlagMetadata() // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -173,10 +173,10 @@ For backwards compatibility, implementations should consider `name` an alias to 
 
 #### Requirement 1.2.3
 
-> The client interface **MUST** define a `all flag metadata` member or accessor, returning a collection of flag metadata from the provider.
+> The client interface **MUST** define a `all flag metadata` member or accessor, containing a `flags` field or accessor which is a collection of flag metadata, from the provider.
 
 ```typescript
-client.getAllFlagMetadata() // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]
+client.getAllFlagMetadata() // { flags: [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}] }
 ```
 
 This may return a language-idiomatic way of describing the absence of a value if the provider does not implement the `allFlagMetadata` member or accessor.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -34,13 +34,7 @@ provider.getMetadata().getName(); // "my-custom-provider"
 provider.getAllFlagMetadata(); // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]
 ```
 
-#### Condition 2.1.3
-
-> The implementing language has an asynchronous support.
-
-##### Conditional Requirement 2.1.3.1
-
-> The accessor for `allFlagMetadata` **SHOULD** be asynchronous.
+For some providers, fetching all flags is an expensive operation. If there is language support, consider implementing this as an asynchronous operation.
 
 ### 2.2 Flag Value Resolution
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -28,13 +28,13 @@ provider.getMetadata().getName(); // "my-custom-provider"
 
 #### Requirement 2.1.2
 
-> The provider **MAY** define an `allFlagMetadata` field or accessor of type collection of flag_metadata, which identifies all available flag keys in the provider.
+> The provider **MAY** define an `all flag metadata` field or accessor of type collection of flag_metadata, which identifies all available flag keys in the provider.
 
 ```typescript
 provider.getAllFlagMetadata(); // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]
 ```
 
-This operation should not be confused with bulk evaluation of all flags.
+This operation should not be confused with a bulk evaluation of all flags.
 This is an informative operation available to clients for understanding which flag keys are currently active from a provider.
 Example usages include building a debug screen based on available flags and detecting stale flag evaluations.
 For some providers, fetching all flags is an expensive operation. If there is language support, consider implementing this as an asynchronous operation.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -34,6 +34,9 @@ provider.getMetadata().getName(); // "my-custom-provider"
 provider.getAllFlagMetadata(); // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]
 ```
 
+This operation should not be confused with bulk evaluation of all flags.
+This is an informative operation available to clients for understanding which flag keys are currently active from a provider.
+Example usages include building a debug screen based on available flags and detecting stale flag evaluations.
 For some providers, fetching all flags is an expensive operation. If there is language support, consider implementing this as an asynchronous operation.
 
 ### 2.2 Flag Value Resolution

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -26,6 +26,22 @@ Providers are the "translator" between the flag evaluation calls made in applica
 provider.getMetadata().getName(); // "my-custom-provider"
 ```
 
+#### Requirement 2.1.2
+
+> The provider `metadata` member or accessor **MAY** define an `allFlagKeys` field or accessor of type collection of strings, which identifies all available flag keys in the provider.
+
+```typescript
+provider.getMetadata().getAllFlagKeys(); // ['featureA', 'featureB']
+```
+
+#### Condition 2.1.3
+
+> The implementing language has an asynchronous support.
+
+##### Conditional Requirement 2.1.3.1
+
+> The accessor for `allFlagKeys` **SHOULD** be asynchronous.
+
 ### 2.2 Flag Value Resolution
 
 `Providers` are implementations of the `feature provider` interface, which may wrap vendor SDKs, REST API clients, or otherwise resolve flag values from the runtime environment.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -38,6 +38,7 @@ This operation should not be confused with a bulk evaluation of all flags.
 This is an informative operation available to clients for understanding which flag keys are currently active from a provider.
 Example usages include building a debug screen based on available flags and detecting stale flag evaluations.
 For some providers, fetching all flags is an expensive operation. If there is language support, consider implementing this as an asynchronous operation.
+If the provider does not implement this behavior or the flag metadata cannot currently be retrieved due to an error status, the language-idiomatic way of describing the absence of a value can be returned from this method.
 
 ### 2.2 Flag Value Resolution
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -28,10 +28,10 @@ provider.getMetadata().getName(); // "my-custom-provider"
 
 #### Requirement 2.1.2
 
-> The provider `metadata` member or accessor **MAY** define an `allFlagKeys` field or accessor of type collection of strings, which identifies all available flag keys in the provider.
+> The provider `metadata` member or accessor **MAY** define an `allFlagMetadata` field or accessor of type collection of [flag_metadata](../types.md#flag-metadata), which identifies all available flag keys in the provider.
 
 ```typescript
-provider.getMetadata().getAllFlagKeys(); // ['featureA', 'featureB']
+provider.getMetadata().getAllFlagMetadata(); // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]
 ```
 
 #### Condition 2.1.3
@@ -40,7 +40,7 @@ provider.getMetadata().getAllFlagKeys(); // ['featureA', 'featureB']
 
 ##### Conditional Requirement 2.1.3.1
 
-> The accessor for `allFlagKeys` **SHOULD** be asynchronous.
+> The accessor for `allFlagMetadata` **SHOULD** be asynchronous.
 
 ### 2.2 Flag Value Resolution
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -28,10 +28,10 @@ provider.getMetadata().getName(); // "my-custom-provider"
 
 #### Requirement 2.1.2
 
-> The provider `metadata` member or accessor **MAY** define an `allFlagMetadata` field or accessor of type collection of [flag_metadata](../types.md#flag-metadata), which identifies all available flag keys in the provider.
+> The provider **MAY** define an `allFlagMetadata` field or accessor of type collection of [flag_metadata](../types.md#flag-metadata), which identifies all available flag keys in the provider.
 
 ```typescript
-provider.getMetadata().getAllFlagMetadata(); // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]
+provider.getAllFlagMetadata(); // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]
 ```
 
 #### Condition 2.1.3

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -28,10 +28,10 @@ provider.getMetadata().getName(); // "my-custom-provider"
 
 #### Requirement 2.1.2
 
-> The provider **MAY** define an `all flag metadata` field or accessor of type collection of flag_metadata, which identifies all available flag keys in the provider.
+> The provider **MAY** define an `all flag metadata` field or accessor, containing a `flags` field or accessor which is a collection of flag metadata, identifying all available flag keys in the provider.
 
 ```typescript
-provider.getAllFlagMetadata(); // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]
+provider.getAllFlagMetadata(); // { flags: [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}] }
 ```
 
 This operation should not be confused with a bulk evaluation of all flags.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -35,7 +35,7 @@ provider.getAllFlagMetadata(); // { flags: [{"key": "featureA", "type": "boolean
 ```
 
 This operation should not be confused with a bulk evaluation of all flags.
-This is an informative operation available to clients for understanding which flag keys are currently active from a provider.
+This is an informative operation available to clients for understanding which flag keys are currently available from a provider.
 Example usages include building a debug screen based on available flags and detecting stale flag evaluations.
 For some providers, fetching all flags is an expensive operation. If there is language support, consider implementing this as an asynchronous operation.
 If the provider does not implement this behavior or the flag metadata cannot currently be retrieved due to an error status, the language-idiomatic way of describing the absence of a value can be returned from this method.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -28,7 +28,7 @@ provider.getMetadata().getName(); // "my-custom-provider"
 
 #### Requirement 2.1.2
 
-> The provider **MAY** define an `allFlagMetadata` field or accessor of type collection of [flag_metadata](../types.md#flag-metadata), which identifies all available flag keys in the provider.
+> The provider **MAY** define an `allFlagMetadata` field or accessor of type collection of flag_metadata, which identifies all available flag keys in the provider.
 
 ```typescript
 provider.getAllFlagMetadata(); // [{"key": "featureA", "type": "boolean"}, {"key": "featureB", "type": "string"}]

--- a/specification/types.md
+++ b/specification/types.md
@@ -138,7 +138,6 @@ A structure which carries information about the provider.
 In addition to the defined metadata fields below, arbitrary information can be stored here unique to the provider.
 
 `name` is a required key with a string value.
-`allFlagKeys` is an optional key with a collection of string value.
 
 ### Provider Status
 

--- a/specification/types.md
+++ b/specification/types.md
@@ -127,6 +127,9 @@ A structure containing the following fields:
 
 A structure which supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean`, `string`, or `number`.
 
+`key` is a required property with a value of `string`.
+`type` is a required property with a `string` value of either `boolean`, `string`, `number`, or `structure`.
+
 This structure is populated by a provider for use by an [Application Author](./glossary.md#application-author) via the [Evaluation API](./glossary.md#evaluation-api) or an [Application Integrator](./glossary.md#application-integrator) via [hooks](./sections/04-hooks.md).
 
 ### Provider Metadata

--- a/specification/types.md
+++ b/specification/types.md
@@ -127,8 +127,8 @@ A structure containing the following fields:
 
 A structure which supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean`, `string`, or `number`.
 
-`key` is a required property with a value of `string`.
-`type` is an optional property with a `string` value indicating which client resolution method should be used to resolve the flag key.
+`key` is a required property with a value of type `string`.
+`type` is an optional property with a value of type `string`, indicating which client resolution method should be used to resolve the flag key.
 
 This structure is populated by a provider for use by an [Application Author](./glossary.md#application-author) via the [Evaluation API](./glossary.md#evaluation-api) or an [Application Integrator](./glossary.md#application-integrator) via [hooks](./sections/04-hooks.md).
 
@@ -137,7 +137,7 @@ This structure is populated by a provider for use by an [Application Author](./g
 A structure which carries information about the provider.
 In addition to the defined metadata fields below, arbitrary information can be stored here unique to the provider.
 
-`name` is a required key with a string value.
+`name` is a required key with a value of type string.
 
 ### Provider Status
 

--- a/specification/types.md
+++ b/specification/types.md
@@ -128,7 +128,7 @@ A structure containing the following fields:
 A structure which supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean`, `string`, or `number`.
 
 `key` is a required property with a value of `string`.
-`type` is a required property with a `string` value of either `boolean`, `string`, `number`, or `structure`.
+`type` is an optional property with a `string` value indicating which client resolution method should be used to resolve the flag key.
 
 This structure is populated by a provider for use by an [Application Author](./glossary.md#application-author) via the [Evaluation API](./glossary.md#evaluation-api) or an [Application Integrator](./glossary.md#application-integrator) via [hooks](./sections/04-hooks.md).
 

--- a/specification/types.md
+++ b/specification/types.md
@@ -28,7 +28,7 @@ Structured data, presented however is idiomatic in the implementation language, 
 
 ### Collection
 
-A list or series of similar data types, presented however is idiomatic in the implementation language.
+An unordered list or series of similar data types, presented however is idiomatic in the implementation language.
 
 ### Datetime
 
@@ -126,6 +126,7 @@ A structure containing the following fields:
 ### Flag Metadata
 
 A structure which supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean`, `string`, or `number`.
+`key` and `type` are reserved properties.
 
 `key` is a required property with a value of type `string`.
 `type` is an optional property with a value of type `string`, indicating which client resolution method should be used to resolve the flag key.

--- a/specification/types.md
+++ b/specification/types.md
@@ -26,6 +26,10 @@ A numeric value of unspecified type or size. Implementation languages may furthe
 
 Structured data, presented however is idiomatic in the implementation language, such as JSON or YAML.
 
+### Collection
+
+A list or series of similar data types, presented however is idiomatic in the implementation language.
+
 ### Datetime
 
 A language primitive for representing a date and time, optionally including timezone information. If no timezone is specified, the date and time will be treated as UTC.
@@ -124,6 +128,14 @@ A structure containing the following fields:
 A structure which supports definition of arbitrary properties, with keys of type `string`, and values of type `boolean`, `string`, or `number`.
 
 This structure is populated by a provider for use by an [Application Author](./glossary.md#application-author) via the [Evaluation API](./glossary.md#evaluation-api) or an [Application Integrator](./glossary.md#application-integrator) via [hooks](./sections/04-hooks.md).
+
+### Provider Metadata
+
+A structure which carries information about the provider.
+In addition to the defined metadata fields below, arbitrary information can be stored here unique to the provider.
+
+`name` is a required key with a string value.
+`allFlagKeys` is an optional key with a collection of string value.
 
 ### Provider Status
 


### PR DESCRIPTION
## This PR
Adds an optional `allFlagMetadata` accessor to clients and the provider interface for retrieving a list of flag keys available in the provider.

- Adds requirements for `allFlagMetadata` accessor
- Defines `Collection` and `Provider Metadata` types in the Types page and adds key information to `Flag Metadata`.

### Related Issues
[Discussion](https://github.com/orgs/open-feature/discussions/338) that predated this proposal.