### PR TITLE
fix: add missing Provider Event Details 'error code' field

### DIFF
--- a/specification/types.md
+++ b/specification/types.md
@@ -146,6 +146,7 @@ A structure defining a provider event payload, including:
 
 - flags changed (string[], optional)
 - message (string, optional)
+- error code ([error code](#error-code), optional)
 - event metadata ([event metadata](#event-metadata))
 
 ### Event Details


### PR DESCRIPTION
Requirement 5.1.5 speaks of a Provider Event Details `error code` field but this field was missing from the specified type. 

This field is required to then populate the Event Details `error code` field.