### PR TITLE
fix: Include hook hints in evaluation options type.

### DIFF
--- a/specification/types.md
+++ b/specification/types.md
@@ -118,6 +118,7 @@ An enumerated error code represented idiomatically in the implementation languag
 A structure containing the following fields:
 
 - hooks (one or more [hooks](./sections/04-hooks.md), optional)
+- hook hints ([hook hints structure](./sections/04-hooks.md#42-hook-hints), optional)
 
 ### Flag Metadata
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
In section 4.5.1 of hooks it specifies:
```
> `Flag evaluation options` **MAY** contain `hook hints`, a map of data to be provided to hook invocations.
```

But it does not include this in the types.md file, which makes this a bit confusing.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

