### PR TITLE
fix: use jsx syntax for legend color

### DIFF
--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -437,7 +437,7 @@ stateDiagram-v2
 
 \* transitions occurring when associated events are spontaneously emitted from the provider
 
-<span style="color:#888">█</span> only defined in static-context (client-side) paradigm
+<span style={{ color: '#888' }}>█</span> only defined in static-context (client-side) paradigm
 
 > [!NOTE]
 > Only SDKs implementing the [static context (client-side) paradigm](../glossary.md#static-context-paradigm) define `RECONCILING` to facilitate [context reconciliation](./02-providers.md#26-provider-context-reconciliation).


### PR DESCRIPTION
This causes an error in the website, it should be JSX.