### PR TITLE
chore: add glossary entry for client object

### DIFF
--- a/specification/appendix-b-gherkin-suites.md
+++ b/specification/appendix-b-gherkin-suites.md
@@ -9,7 +9,7 @@ sidebar_position: 5
 
 This section contains a set of language-agnostic end-to-end tests (defined in gherkin).
 These tests can be used to validate the behavior of an OpenFeature implementation.
-"Features" (test suites) can be used in conjunction with a cucumber test-runner for the language in question.
+"Features" (test suites) can be used in conjunction with an [in-memory provider](./appendix-a-included-utilities.md#in-memory-provider) and a cucumber test-runner for the language in question.
 
 ## Evaluation Feature
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -27,6 +27,7 @@ This document defines some terms that are used across this specification.
   - [Feature Flag API](#feature-flag-api)
   - [Evaluation API](#evaluation-api)
   - [Flag Management System](#flag-management-system)
+  - [Client](#client)
   - [Provider](#provider)
   - [Provider Lifecycle](#provider-lifecycle)
   - [Domain](#domain)
@@ -105,6 +106,11 @@ The subset of the [Feature Flag API](#feature-flag-api) that the Application Aut
 ### Flag Management System
 
 A source-of-truth for flag values and rules. Flag management systems may include SaaS feature flag vendors, custom "in-house" feature flag infrastructure, or open-source implementations.
+
+### Client
+
+A lightweight abstraction which provides functions to evaluate feature flags.
+A client is associated with a single provider, which it uses to perform evaluations.
 
 ### Provider
 


### PR DESCRIPTION
I've been missing this glossary entry for some recent content.