### PR TITLE
feat: tracking

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -509,6 +509,13 @@
             "children": []
         },
         {
+            "id": "Condition 2.7.1",
+            "machine_id": "condition_2_7_1",
+            "content": "The `provider` MAY define a function for tracking the occurrence of a particular user action or application state, with parameters `occurrence key` (string, required), `evaluation context` (optional) and `occurrence details` (optional) which returns nothing.",
+            "RFC 2119 keyword": "MAY",
+            "children": []
+        },
+        {
             "id": "Requirement 3.1.1",
             "machine_id": "requirement_3_1_1",
             "content": "The `evaluation context` structure MUST define an optional `targeting key` field of type string, identifying the subject of the flag evaluation.",
@@ -1042,6 +1049,50 @@
             "id": "Requirement 5.3.5",
             "machine_id": "requirement_5_3_5",
             "content": "If the provider emits an event, the value of the client's `provider status` MUST be updated accordingly.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Condition 6.1.1",
+            "machine_id": "condition_6_1_1",
+            "content": "The implementation uses the dynamic-context paradigm.",
+            "RFC 2119 keyword": null,
+            "children": [
+                {
+                    "id": "Conditional Requirement 6.1.1.1",
+                    "machine_id": "conditional_requirement_6_1_1_1",
+                    "content": "The `client` MUST define a function for tracking the occurrence of a particular action or application state, with parameters `occurrence key` (string, required), `evaluation context` (optional) and `occurrence details` (optional) which returns nothing.",
+                    "RFC 2119 keyword": "MUST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "id": "Condition 6.1.2",
+            "machine_id": "condition_6_1_2",
+            "content": "The implementation uses the static-context paradigm.",
+            "RFC 2119 keyword": null,
+            "children": [
+                {
+                    "id": "Conditional Requirement 6.1.2.1",
+                    "machine_id": "conditional_requirement_6_1_2_1",
+                    "content": "The `client` MUST define a function for tracking the occurrence of a particular action or application state, with parameters `occurrence key` (string, required) and `occurrence details` (optional) which returns nothing.",
+                    "RFC 2119 keyword": "MUST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "id": "Requirement 6.1.3",
+            "machine_id": "requirement_6_1_3",
+            "content": "The evaluation context passed to the provider's track function MUST be merged in the order: API (global; lowest precedence) - transaction - client - invocation (highest precedence), with duplicate values being overwritten.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Requirement 6.1.4",
+            "machine_id": "requirement_6_1_4",
+            "content": "If the client's `track` function is called and the associated provider does not implement tracking, the client's `track` function MUST no-op.",
             "RFC 2119 keyword": "MUST",
             "children": []
         }

--- a/specification.json
+++ b/specification.json
@@ -1095,6 +1095,20 @@
             "content": "If the client's `track` function is called and the associated provider does not implement tracking, the client's `track` function MUST no-op.",
             "RFC 2119 keyword": "MUST",
             "children": []
+        },
+        {
+            "id": "Requirement 6.2.1",
+            "machine_id": "requirement_6_2_1",
+            "content": "The `occurrence details` structure MUST define an optional numeric `value`, associating a scalar quality with an `occurrence`.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Requirement 6.2.2",
+            "machine_id": "requirement_6_2_2",
+            "content": "The `occurrence details` MUST support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | structure`.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
         }
     ]
 }

--- a/specification.json
+++ b/specification.json
@@ -511,7 +511,7 @@
         {
             "id": "Condition 2.7.1",
             "machine_id": "condition_2_7_1",
-            "content": "The `provider` MAY define a function for tracking the occurrence of a particular user action or application state, with parameters `occurrence key` (string, required), `evaluation context` (optional) and `occurrence details` (optional) which returns nothing.",
+            "content": "The `provider` MAY define a function for tracking the occurrence of a particular user action or application state, with parameters `tracking event name` (string, required), `evaluation context` (optional) and `tracking event details` (optional) which returns nothing.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -1061,7 +1061,7 @@
                 {
                     "id": "Conditional Requirement 6.1.1.1",
                     "machine_id": "conditional_requirement_6_1_1_1",
-                    "content": "The `client` MUST define a function for tracking the occurrence of a particular action or application state, with parameters `occurrence key` (string, required), `evaluation context` (optional) and `occurrence details` (optional) which returns nothing.",
+                    "content": "The `client` MUST define a function for tracking the occurrence of a particular action or application state, with parameters `tracking event name` (string, required), `evaluation context` (optional) and `tracking event details` (optional), which returns nothing.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 }
@@ -1076,7 +1076,7 @@
                 {
                     "id": "Conditional Requirement 6.1.2.1",
                     "machine_id": "conditional_requirement_6_1_2_1",
-                    "content": "The `client` MUST define a function for tracking the occurrence of a particular action or application state, with parameters `occurrence key` (string, required) and `occurrence details` (optional) which returns nothing.",
+                    "content": "The `client` MUST define a function for tracking the occurrence of a particular action or application state, with parameters `tracking event name` (string, required) and `tracking event details` (optional), which returns nothing.",
                     "RFC 2119 keyword": "MUST",
                     "children": []
                 }
@@ -1099,14 +1099,14 @@
         {
             "id": "Requirement 6.2.1",
             "machine_id": "requirement_6_2_1",
-            "content": "The `occurrence details` structure MUST define an optional numeric `value`, associating a scalar quality with an `occurrence`.",
+            "content": "The `tracking event details` structure MUST define an optional numeric `value`, associating a scalar quality with an `tracking event`.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 6.2.2",
             "machine_id": "requirement_6_2_2",
-            "content": "The `occurrence details` MUST support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | structure`.",
+            "content": "The `tracking event details` MUST support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | structure`.",
             "RFC 2119 keyword": "MUST",
             "children": []
         }

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -46,7 +46,7 @@ This document defines some terms that are used across this specification.
   - [Targeting Key](#targeting-key)
   - [Fractional Evaluation](#fractional-evaluation)
   - [Rule](#rule)
-  - [Tracking Occurrence](#tracking-occurrence)
+  - [Tracking Event](#tracking-event)
 - [SDK Paradigms](#sdk-paradigms)
   - [Dynamic-Context Paradigm](#dynamic-context-paradigm)
   - [Static-Context Paradigm](#static-context-paradigm)
@@ -201,7 +201,7 @@ Pseudorandomly resolve flag values using a context property, such as a targeting
 
 A rule is some criteria that's used to determine which variant a particular context should be mapped to.
 
-### Tracking Occurrence
+### Tracking Event
 
 A particular user action or application state representing a business objective or outcome, identified by a unique string, and recorded using the [tracking API](./sections/06-tracking.md).
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -46,6 +46,7 @@ This document defines some terms that are used across this specification.
   - [Targeting Key](#targeting-key)
   - [Fractional Evaluation](#fractional-evaluation)
   - [Rule](#rule)
+  - [Tracking Occurrence](#tracking-occurrence)
 - [SDK Paradigms](#sdk-paradigms)
   - [Dynamic-Context Paradigm](#dynamic-context-paradigm)
   - [Static-Context Paradigm](#static-context-paradigm)
@@ -199,6 +200,10 @@ Pseudorandomly resolve flag values using a context property, such as a targeting
 ### Rule
 
 A rule is some criteria that's used to determine which variant a particular context should be mapped to.
+
+### Tracking Occurrence
+
+A particular user action or application state representing a business objective or outcome, identified by a unique string, and recorded using the [tracking API](./sections/06-tracking.md).
 
 ## SDK Paradigms
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -36,6 +36,7 @@ This document defines some terms that are used across this specification.
   - [Transaction Context Propagator](#transaction-context-propagator)
   - [Evaluating Flag Values](#evaluating-flag-values)
   - [Resolving Flag Values](#resolving-flag-values)
+  - [Tracking Event](#tracking-event)
 - [Flagging specifics](#flagging-specifics)
   - [Flag](#flag)
   - [Flag Set](#flag-set)
@@ -46,7 +47,6 @@ This document defines some terms that are used across this specification.
   - [Targeting Key](#targeting-key)
   - [Fractional Evaluation](#fractional-evaluation)
   - [Rule](#rule)
-  - [Tracking Event](#tracking-event)
 - [SDK Paradigms](#sdk-paradigms)
   - [Dynamic-Context Paradigm](#dynamic-context-paradigm)
   - [Static-Context Paradigm](#static-context-paradigm)
@@ -149,6 +149,10 @@ The process of retrieving a feature flag value in it's entirety, including:
 
 The process of a provider retrieving a feature flag value from it's particular source-of-truth.
 
+### Tracking Event
+
+A particular user action or application state representing a business objective or outcome, identified by a unique string, and recorded using the [tracking API](./sections/06-tracking.md).
+
 ## Flagging specifics
 
 ```mermaid
@@ -200,10 +204,6 @@ Pseudorandomly resolve flag values using a context property, such as a targeting
 ### Rule
 
 A rule is some criteria that's used to determine which variant a particular context should be mapped to.
-
-### Tracking Event
-
-A particular user action or application state representing a business objective or outcome, identified by a unique string, and recorded using the [tracking API](./sections/06-tracking.md).
 
 ## SDK Paradigms
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -261,3 +261,34 @@ class MyProvider implements Provider {
 Providers may maintain remote connections, timers, threads or other constructs that need to be appropriately disposed of.
 Provider authors may implement a `shutdown` function to perform relevant clean-up actions.
 Alternatively, implementations might leverage language idioms such as auto-disposable interfaces or some means of cancellation signal propagation to allow for graceful shutdown.
+
+### 2.7. Tracking Support
+
+[![experimental](https://img.shields.io/static/v1?label=Status&message=experimental&color=orange)](https://github.com/open-feature/spec/tree/main/specification#experimental)
+
+Some flag management systems support tracking functionality, which associates feature flag evaluations with subsequent user actions or application state.
+
+See [tracking](./06-tracking.md).
+
+#### Condition 2.7.1
+
+> The `provider` **MAY** define a function for tracking the occurrence of a particular user action or application state, with parameters `occurrence key` (string, required), `evaluation context` (optional) and `occurrence details` (optional) which returns nothing.
+
+```java
+class MyProvider implements Tracking {
+  //...
+
+  /**
+   * Record a tracking occurrence.
+   */
+  void track(String occurrenceKey, OccurrenceDetails details, EvaluationContext context): void;
+  
+  //...
+}
+```
+
+The track function is a void function (function returning nothing).
+The track function performs side effects required to record the `occurrence` in question, which may include network activity or other I/O; this I/O should not block the function call.
+Providers should be careful to complete any communication or flush any relevant uncommitted tracking data before they shut down.
+
+See [shutdown](#25-shutdown).

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -281,7 +281,7 @@ class MyProvider implements Tracking {
   /**
    * Record a tracking occurrence.
    */
-  void track(String occurrenceKey, EvaluationContext context, OccurrenceDetails details): void;
+  void track(String trackingEventName, EvaluationContext context, TrackingEventDetails details): void;
   
   //...
 }

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -272,14 +272,14 @@ See [tracking](./06-tracking.md).
 
 #### Condition 2.7.1
 
-> The `provider` **MAY** define a function for tracking the occurrence of a particular user action or application state, with parameters `occurrence key` (string, required), `evaluation context` (optional) and `occurrence details` (optional) which returns nothing.
+> The `provider` **MAY** define a function for tracking the occurrence of a particular user action or application state, with parameters `tracking event name` (string, required), `evaluation context` (optional) and `tracking event details` (optional) which returns nothing.
 
 ```java
 class MyProvider implements Tracking {
   //...
 
   /**
-   * Record a tracking occurrence.
+   * Record a tracking event.
    */
   void track(String trackingEventName, EvaluationContext context, TrackingEventDetails details): void;
   
@@ -288,7 +288,7 @@ class MyProvider implements Tracking {
 ```
 
 The track function is a void function (function returning nothing).
-The track function performs side effects required to record the `occurrence` in question, which may include network activity or other I/O; this I/O should not block the function call.
+The track function performs side effects required to record the `tracking event` in question, which may include network activity or other I/O; this I/O should not block the function call.
 Providers should be careful to complete any communication or flush any relevant uncommitted tracking data before they shut down.
 
 See [shutdown](#25-shutdown).

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -266,7 +266,7 @@ Alternatively, implementations might leverage language idioms such as auto-dispo
 
 [![experimental](https://img.shields.io/static/v1?label=Status&message=experimental&color=orange)](https://github.com/open-feature/spec/tree/main/specification#experimental)
 
-Some flag management systems support tracking functionality, which associates feature flag evaluations with subsequent user actions or application state.
+Some flag management systems support tracking functionality, which can be used to associate feature flag evaluations with subsequent user actions or application state.
 
 See [tracking](./06-tracking.md).
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -281,7 +281,7 @@ class MyProvider implements Tracking {
   /**
    * Record a tracking occurrence.
    */
-  void track(String occurrenceKey, OccurrenceDetails details, EvaluationContext context): void;
+  void track(String occurrenceKey, EvaluationContext context, OccurrenceDetails details): void;
   
   //...
 }

--- a/specification/sections/06-tracking.md
+++ b/specification/sections/06-tracking.md
@@ -33,20 +33,20 @@ see: [dynamic-context paradigm](../glossary.md#dynamic-context-paradigm)
 
 ##### Conditional Requirement 6.1.1.1
 
-> The `client` **MUST** define a function for tracking the occurrence of a particular action or application state, with parameters `occurrence key` (string, required), `evaluation context` (optional) and `occurrence details` (optional) which returns nothing.
+> The `client` **MUST** define a function for tracking the occurrence of a particular action or application state, with parameters `tracking event name` (string, required), `evaluation context` (optional) and `tracking event details` (optional), which returns nothing.
 
 ```java
-// example tracking occurrence recording that a subject reached a page associated with a business goal
+// example tracking event recording that a subject reached a page associated with a business goal
 client.track("visited-promo-page", evaluationContext);
 
-// example tracking occurrence recording that a subject performed an action associated with a business goal, with the occurrence details having a particular numeric value
-client.track("clicked-checkout", evaluationContext, new OccurrenceDetails(99.77));
+// example tracking event recording that a subject performed an action associated with a business goal, with the tracking event details having a particular numeric value
+client.track("clicked-checkout", evaluationContext, new TrackingEventDetails(99.77));
 
-// example tracking occurrence recording that a subject performed an action associated with a business goal, with the occurrence details having a particular numeric value
-client.track("clicked-checkout", evaluationContext, new OccurrenceDetails(99.77).add("currencyCode", "USD"));
+// example tracking event recording that a subject performed an action associated with a business goal, with the tracking event details having a particular numeric value
+client.track("clicked-checkout", evaluationContext, new TrackingEventDetails(99.77).add("currencyCode", "USD"));
 ```
 
-See [evaluation context](../types.md#evaluation-context), [occurrence details](#62-occurrence-details).
+See [evaluation context](../types.md#evaluation-context), [tracking event details](#62-tracking-event-details).
 
 #### Condition 6.1.2
 
@@ -58,20 +58,20 @@ see: [static-context paradigm](../glossary.md#static-context-paradigm)
 
 ##### Conditional Requirement 6.1.2.1
 
-> The `client` **MUST** define a function for tracking the occurrence of a particular action or application state, with parameters `occurrence key` (string, required) and `occurrence details` (optional) which returns nothing.
+> The `client` **MUST** define a function for tracking the occurrence of a particular action or application state, with parameters `tracking event name` (string, required) and `tracking event details` (optional), which returns nothing.
 
 The track function is a void function (function returning nothing).
 Though it may be associated with network activity or other I/O, it need not be awaited by application authors.
 
 ```java
-// example tracking occurrence recording that a subject reached a page associated with a business goal
+// example tracking event recording that a subject reached a page associated with a business goal
 client.track("visited-promo-page");
 
-// example tracking occurrence recording that a subject performed an action associated with a business goal, with the occurrence details having a particular numeric value
-client.track("clicked-checkout", new OccurrenceDetails(99.77));
+// example tracking event recording that a subject performed an action associated with a business goal, with the tracking event details having a particular numeric value
+client.track("clicked-checkout", new TrackingEventDetails(99.77));
 
-// example tracking occurrence recording that a subject performed an action associated with a business goal, with the occurrence details having a particular numeric and some additional details
-client.track("clicked-checkout", new OccurrenceDetails(99.77).add("currencyCode", "USD"));
+// example tracking event recording that a subject performed an action associated with a business goal, with the tracking event details having a particular numeric and some additional details
+client.track("clicked-checkout", new TrackingEventDetails(99.77).add("currencyCode", "USD"));
 ```
 
 #### Requirement 6.1.3
@@ -86,13 +86,13 @@ See: [context levels and merging](./03-evaluation-context.md#32-context-levels-a
 
 > If the client's `track` function is called and the associated provider does not implement tracking, the client's `track` function **MUST** no-op.
 
-### 6.2. Occurrence Details
+### 6.2. Tracking Event Details
 
-The `occurrence details` structure defines optional data pertinent to a particular `occurrence`.
+The `tracking event details` structure defines optional data pertinent to a particular `tracking event`.
 
 #### Requirement 6.2.1
 
-> The `occurrence details` structure **MUST** define an optional numeric `value`, associating a scalar quality with an `occurrence`.
+> The `tracking event details` structure **MUST** define an optional numeric `value`, associating a scalar quality with an `tracking event`.
 
 `Value` is a well-defined field which some providers may map to equivalent numeric values in their API.
 
@@ -100,8 +100,8 @@ See [provider tracking support](./02-providers.md#27-tracking-support).
 
 #### Requirement 6.2.2
 
-> The `occurrence details` **MUST** support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | structure`.
+> The `tracking event details` **MUST** support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | structure`.
 
-The `occurrence details` supports the addition of arbitrary fields, including nested objects, similar to the `evaluation context` and object-typed flag values.
+The `tracking event details` supports the addition of arbitrary fields, including nested objects, similar to the `evaluation context` and object-typed flag values.
 
 See [structure](../types.md#structure), [evaluation context](.//03-evaluation-context.md).

--- a/specification/sections/06-tracking.md
+++ b/specification/sections/06-tracking.md
@@ -10,7 +10,7 @@ toc_max_heading_level: 4
 
 ## Overview
 
-The `tracking API` enables the association of feature flag evaluations with subsequent actions or application states, in order to facilitate experimentation, and analysis of the impact of feature flags on business objectives.
+The `tracking API` enables the association of feature flag evaluations with subsequent actions or application states, in order to facilitate experimentation and analysis of the impact of feature flags on business objectives.
 
 Combined with hooks which report feature flag evaluations to the analytics platform in question, tracking can allow for robust experimentation even for flag management systems that don't support tracking directly.
 

--- a/specification/sections/06-tracking.md
+++ b/specification/sections/06-tracking.md
@@ -40,7 +40,10 @@ see: [dynamic-context paradigm](../glossary.md#dynamic-context-paradigm)
 client.track("visited-promo-page", evaluationContext);
 
 // example tracking occurrence recording that a subject performed an action associated with a business goal, with the occurrence details having a particular numeric value
-client.track("clicked-checkout", evaluationContext, new OccurrenceDetails(99.77)): void;
+client.track("clicked-checkout", evaluationContext, new OccurrenceDetails(99.77));
+
+// example tracking occurrence recording that a subject performed an action associated with a business goal, with the occurrence details having a particular numeric value
+client.track("clicked-checkout", evaluationContext, new OccurrenceDetails(99.77).add("currencyCode", "USD"));
 ```
 
 See [evaluation context](../types.md#evaluation-context), [occurrence details](#62-occurrence-details).
@@ -65,7 +68,10 @@ Though it may be associated with network activity or other I/O, it need not be a
 client.track("visited-promo-page");
 
 // example tracking occurrence recording that a subject performed an action associated with a business goal, with the occurrence details having a particular numeric value
-client.track("clicked-checkout", new OccurrenceDetails(99.77)): void;
+client.track("clicked-checkout", new OccurrenceDetails(99.77));
+
+// example tracking occurrence recording that a subject performed an action associated with a business goal, with the occurrence details having a particular numeric and some additional details
+client.track("clicked-checkout", new OccurrenceDetails(99.77).add("currencyCode", "USD"));
 ```
 
 #### Requirement 6.1.3

--- a/specification/sections/06-tracking.md
+++ b/specification/sections/06-tracking.md
@@ -10,35 +10,88 @@ toc_max_heading_level: 4
 
 ## Overview
 
-Experimentation is a primary use case for feature flags.
-In practice, this often means flag variants are assigned to users at random or in accordance with a business rule, while the impact of the assigned variant on some business objective is measured.
-Vendors and custom solutions often support a _tracking_ or _goal measuring_ API to facilitate the measurement of these business objectives.
+The `tracking API` enables the association of feature flag evaluations with subsequent actions or application states, in order to facilitate experimentation, and analysis of the impact of feature flags on business objectives.
 
-### Goals
+Combined with hooks which report feature flag evaluations to the analytics platform in question, tracking can allow for robust experimentation even for flag management systems that don't support tracking directly.
 
-- Develop official terminology to support consistent implementation
-- Specify a flexible API widely compatible with basic vendor functionality
-  - Define tracking event payload
-  - Define tracking event identifier
-  - Support A/B testing and experimentation use-cases
-  - Support client and server paradigms
-  - Provide recommendations around: 
-    - Async vs sync
-    - Flushing mechanisms
-    - Event batching
+```mermaid
+sequenceDiagram
+  Evaluation API->>+Tracking Hook: evaluate
+  Tracking Hook->>Analytics Platform: before
+  Tracking Hook->>Analytics Platform: after
+  Tracking Hook->>-Evaluation API: evaluate
+  Evaluation API->>Analytics Platform: track
+```
 
-### Non-goals
+### 6.1. Tracking API
 
-- Creating an experimentation platform
-- Covering every user-tracking use case
-  - We will not define any data aggregation mechanisms
-  - We will not focus on "metrics", but instead, "facts"
+#### Condition 6.1.1
 
-### Design Principles
+> The implementation uses the dynamic-context paradigm.
 
-We value the following:
+see: [dynamic-context paradigm](../glossary.md#dynamic-context-paradigm)
 
-- Adherence to, and compatibility with OpenFeature semantics
-- Maximum compatibility and ease-of-adoption for existing solutions
-- Minimum traffic and payload size
-- Ease-of-use for application authors, integrators, and provider authors (in that order)
+##### Conditional Requirement 6.1.1.1
+
+> The `client` **MUST** define a function for tracking the occurrence of a particular action or application state, with parameters `occurrence key` (string, required), `evaluation context` (optional) and `occurrence details` (optional) which returns nothing.
+
+```java
+// example tracking occurrence recording that a subject reached a page associated with a business goal
+client.track("visited-promo-page", evaluationContext);
+
+// example tracking occurrence recording that a subject performed an action associated with a business goal, with the occurrence details having a particular numeric value
+client.track("clicked-checkout", evaluationContext, new OccurrenceDetails(99.77)): void;
+```
+
+See [evaluation context](../types.md#evaluation-context), [occurrence details](#62-occurrence-details).
+
+#### Condition 6.1.2
+
+[![experimental](https://img.shields.io/static/v1?label=Status&message=experimental&color=orange)](https://github.com/open-feature/spec/tree/main/specification#experimental)
+
+> The implementation uses the static-context paradigm.
+
+see: [static-context paradigm](../glossary.md#static-context-paradigm)
+
+##### Conditional Requirement 6.1.2.1
+
+> The `client` **MUST** define a function for tracking the occurrence of a particular action or application state, with parameters `occurrence key` (string, required) and `occurrence details` (optional) which returns nothing.
+
+The track function is a void function (function returning nothing).
+Though it may be associated with network activity or other I/O, it need not be awaited by application authors.
+
+```java
+// example tracking occurrence recording that a subject reached a page associated with a business goal
+client.track("visited-promo-page");
+
+// example tracking occurrence recording that a subject performed an action associated with a business goal, with the occurrence details having a particular numeric value
+client.track("clicked-checkout", new OccurrenceDetails(99.77)): void;
+```
+
+#### Requirement 6.1.3
+
+> The evaluation context passed to the provider's track function **MUST** be merged in the order: API (global; lowest precedence) -> transaction -> client -> invocation (highest precedence), with duplicate values being overwritten.
+
+The SDK passes a merged evaluation context to the provider's track function similarly to the manner it does in resolvers.
+
+See: [context levels and merging](./03-evaluation-context.md#32-context-levels-and-merging).
+
+#### Requirement 6.1.4
+
+> If the client's `track` function is called and the associated provider does not implement tracking, the client's `track` function **MUST** no-op.
+
+## 6.2. Occurrence Details
+
+The `occurrence details` structure defines optional data pertinent to a particular `occurrence`.
+
+### Requirement 6.2.1
+
+> The `occurrence details` structure **MUST** define an optional numeric `value`, associating a scalar quality with an `occurrence`.
+
+`Value` is a well-defined field which some providers may map to equivalent numeric values in their API.
+
+See [provider tracking support](./02-providers.md#27-tracking-support).
+
+### Requirement 6.2.2
+
+> The `occurrence details` **MUST** support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number`.

--- a/specification/sections/06-tracking.md
+++ b/specification/sections/06-tracking.md
@@ -80,11 +80,11 @@ See: [context levels and merging](./03-evaluation-context.md#32-context-levels-a
 
 > If the client's `track` function is called and the associated provider does not implement tracking, the client's `track` function **MUST** no-op.
 
-## 6.2. Occurrence Details
+### 6.2. Occurrence Details
 
 The `occurrence details` structure defines optional data pertinent to a particular `occurrence`.
 
-### Requirement 6.2.1
+#### Requirement 6.2.1
 
 > The `occurrence details` structure **MUST** define an optional numeric `value`, associating a scalar quality with an `occurrence`.
 
@@ -92,6 +92,10 @@ The `occurrence details` structure defines optional data pertinent to a particul
 
 See [provider tracking support](./02-providers.md#27-tracking-support).
 
-### Requirement 6.2.2
+#### Requirement 6.2.2
 
-> The `occurrence details` **MUST** support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number`.
+> The `occurrence details` **MUST** support the inclusion of custom fields, having keys of type `string`, and values of type `boolean | string | number | structure`.
+
+The `occurrence details` supports the addition of arbitrary fields, including nested objects, similar to the `evaluation context` and object-typed flag values.
+
+See [structure](../types.md#structure), [evaluation context](.//03-evaluation-context.md).

--- a/specification/types.md
+++ b/specification/types.md
@@ -113,6 +113,10 @@ An enumerated error code represented idiomatically in the implementation languag
 | PROVIDER_FATAL        | The provider has entered an irrecoverable error state.                                      |
 | GENERAL               | The error was for a reason not enumerated above.                                            |
 
+### Evaluation Context
+
+See [evaluation context](./sections/03-evaluation-context.md).
+
 ### Evaluation Options
 
 A structure containing the following fields:
@@ -184,3 +188,7 @@ An enumeration of provider events.
 
 A function or method which can be associated with a `provider event`, and runs when that event occurs.
 It declares an `event details` parameter.
+
+### Occurrence Details
+
+See [occurrence details](./sections/06-tracking.md#62-occurrence-details).\

--- a/specification/types.md
+++ b/specification/types.md
@@ -189,6 +189,8 @@ An enumeration of provider events.
 A function or method which can be associated with a `provider event`, and runs when that event occurs.
 It declares an `event details` parameter.
 
-### Occurrence Details
+### Tracking Event Details
 
-See [occurrence details](./sections/06-tracking.md#62-occurrence-details).
+A structure which supports definition of arbitrary properties, including nested objects, similar to the `evaluation context` and object-typed flag values.
+
+See [tracking event details](./sections/06-tracking.md#62-tracking-event-details), [evaluation context](#evaluation-context).

--- a/specification/types.md
+++ b/specification/types.md
@@ -191,4 +191,4 @@ It declares an `event details` parameter.
 
 ### Occurrence Details
 
-See [occurrence details](./sections/06-tracking.md#62-occurrence-details).\
+See [occurrence details](./sections/06-tracking.md#62-occurrence-details).


### PR DESCRIPTION
Adds tracking

---

This PR is a first pass at a relatively simple tracking API. The main purpose is to close what is more or less the last gap between the OpenFeature API and that of most SDKs (many SDKs which we currently support have some kind of simple "track" method analogous to what's proposed here). Preceding discussion can be found [here](https://github.com/orgs/open-feature/discussions/376).

Some notable choices:

- I've used the term "occurrence" instead of "event" to minimize terminology overloading
- I've ordered the parameters for the tracking method `occurrenceKey`/`context`/`occurrenceDetails`.
- I've specified the `track` method should never block but instead queue any async work; we agreed there's no reason an application author would ever want to await a I/O associated with a single `track` call; most providers will batch these, I assume
- I've made `value` a "first class" property of the otherwise free-form `OccurrenceDetails` type, so it can be easily mapped into the equivalent field of various providers (something like `targetingKey`)