### PR TITLE
chore: use html entity code for asterisk in mermaid diagram

### DIFF
--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -426,11 +426,11 @@ stateDiagram-v2
     NOT_READY --> ERROR:initialize()
     NOT_READY --> FATAL:initialize()
     FATAL --> [*]
-    READY --> ERROR:*
-    ERROR --> READY:*
-    READY --> STALE:*
-    STALE --> READY:*
-    STALE --> ERROR:*
+    READY --> ERROR:#ast;
+    ERROR --> READY:#ast;
+    READY --> STALE:#ast;
+    STALE --> READY:#ast;
+    STALE --> ERROR:#ast;
     READY --> NOT_READY:shutdown()
     STALE --> NOT_READY:shutdown()
     ERROR --> NOT_READY:shutdown()


### PR DESCRIPTION
## This PR

![image](https://github.com/user-attachments/assets/a9f99589-f78d-49f0-a8ed-dfa93710e704)

The mermaid diagram for `Provider lifecycle` has few arrows with `Unsupported markdown: list` text. It will be fixed by using `#ast`;



https://mermaid.js.org/syntax/flowchart.html#entity-codes-to-escape-characters
