### PR TITLE
Add gherkin tests to verify evaluation details in finally hooks

### DIFF
--- a/specification/assets/gherkin/evaluation.feature
+++ b/specification/assets/gherkin/evaluation.feature
@@ -3,7 +3,7 @@ Feature: Flag evaluation
 # This test suite contains scenarios to test the flag evaluation API.
 
   Background:
-    Given a provider is registered
+    Given a provider is registered with cache disabled
 
   # basic evaluation
   Scenario: Resolves boolean value
@@ -48,6 +48,19 @@ Feature: Flag evaluation
     Then the resolved object details value should be contain fields "showImages", "title", and "imagesPerPage", with values "true", "Check out these pics!" and 100, respectively
     And the variant should be "template", and the reason should be "STATIC"
 
+  Scenario: Passes evaluation details to finally hooks
+    When a hook is added to the client
+    And a boolean flag with key "boolean-flag" is evaluated with details and default value "false"
+    Then non-error hooks should be called
+    And "after, finally after" hook should have evaluation details
+      | flag_type | key           | value        |
+      | string    | flag_key      | boolean-flag |
+      | boolean   | value         | true         |
+      | string    | variant       | on           |
+      | string    | reason        | STATIC       |
+      | string    | error_code    | None         |
+      | string    | error_message | None         |
+
   # context-aware evaluation
   Scenario: Resolves based on context
     When context contains keys "fn", "ln", "age", "customer" with values "Sulisław", "Świętopełk", 29, "false"
@@ -57,11 +70,31 @@ Feature: Flag evaluation
 
   # errors
   Scenario: Flag not found
-    When a non-existent string flag with key "missing-flag" is evaluated with details and a default value "uh-oh"
+    When a hook is added to the client
+    And a non-existent string flag with key "missing-flag" is evaluated with details and a default value "uh-oh"
     Then the default string value should be returned
     And the reason should indicate an error and the error code should indicate a missing flag with "FLAG_NOT_FOUND"
+    And error hooks should be called
+    And "finally after" hook should have evaluation details
+      | type   | key           | value                         |
+      | string | flag_key      | missing-flag                  |
+      | string | value         | uh-oh                         |
+      | string | variant       | None                          |
+      | string | reason        | ERROR                         |
+      | string | error_code    | ErrorCode.FLAG_NOT_FOUND      |
+      | string | error_message | Flag 'missing-flag' not found |
 
   Scenario: Type error
-    When a string flag with key "wrong-flag" is evaluated as an integer, with details and a default value 13
+    When a hook is added to the client
+    And a string flag with key "wrong-flag" is evaluated as an integer, with details and a default value 13
     Then the default integer value should be returned
     And the reason should indicate an error and the error code should indicate a type mismatch with "TYPE_MISMATCH"
+    And error hooks should be called
+    And "finally after" hook should have evaluation details
+      | type    | key           | value                                             |
+      | string  | flag_key      | wrong-flag                                        |
+      | integer | value         | 13                                                |
+      | string  | variant       | None                                              |
+      | string  | reason        | ERROR                                             |
+      | string  | error_code    | ErrorCode.TYPE_MISMATCH                           |
+      | string  | error_message | Expected type <class 'int'> but got <class 'str'> |

--- a/specification/assets/gherkin/evaluation.feature
+++ b/specification/assets/gherkin/evaluation.feature
@@ -48,11 +48,11 @@ Feature: Flag evaluation
     Then the resolved object details value should be contain fields "showImages", "title", and "imagesPerPage", with values "true", "Check out these pics!" and 100, respectively
     And the variant should be "template", and the reason should be "STATIC"
 
-  Scenario: Passes evaluation details to finally hooks
+  Scenario: Passes evaluation details to after and finally hooks
     When a hook is added to the client
     And a boolean flag with key "boolean-flag" is evaluated with details and default value "false"
-    Then non-error hooks should be called
-    And "after, finally after" hook should have evaluation details
+    Then "before" hooks should be called
+    And "after, finally after" hooks should be called with evaluation details
       | flag_type | key           | value        |
       | string    | flag_key      | boolean-flag |
       | boolean   | value         | true         |
@@ -74,8 +74,8 @@ Feature: Flag evaluation
     And a non-existent string flag with key "missing-flag" is evaluated with details and a default value "uh-oh"
     Then the default string value should be returned
     And the reason should indicate an error and the error code should indicate a missing flag with "FLAG_NOT_FOUND"
-    And error hooks should be called
-    And "finally after" hook should have evaluation details
+    Then "before, error" hooks should be called
+    And "finally after" hooks should be called with evaluation details
       | type   | key           | value                         |
       | string | flag_key      | missing-flag                  |
       | string | value         | uh-oh                         |
@@ -89,8 +89,8 @@ Feature: Flag evaluation
     And a string flag with key "wrong-flag" is evaluated as an integer, with details and a default value 13
     Then the default integer value should be returned
     And the reason should indicate an error and the error code should indicate a type mismatch with "TYPE_MISMATCH"
-    And error hooks should be called
-    And "finally after" hook should have evaluation details
+    Then "before, error" hooks should be called
+    And "finally after" hooks should be called with evaluation details
       | type    | key           | value                                             |
       | string  | flag_key      | wrong-flag                                        |
       | integer | value         | 13                                                |

--- a/specification/assets/gherkin/evaluation.feature
+++ b/specification/assets/gherkin/evaluation.feature
@@ -3,7 +3,7 @@ Feature: Flag evaluation
 # This test suite contains scenarios to test the flag evaluation API.
 
   Background:
-    Given a provider is registered with cache disabled
+    Given a stable provider
 
   # basic evaluation
   Scenario: Resolves boolean value

--- a/specification/assets/gherkin/evaluation.feature
+++ b/specification/assets/gherkin/evaluation.feature
@@ -48,19 +48,6 @@ Feature: Flag evaluation
     Then the resolved object details value should be contain fields "showImages", "title", and "imagesPerPage", with values "true", "Check out these pics!" and 100, respectively
     And the variant should be "template", and the reason should be "STATIC"
 
-  Scenario: Passes evaluation details to after and finally hooks
-    When a hook is added to the client
-    And a boolean flag with key "boolean-flag" is evaluated with details and default value "false"
-    Then "before" hooks should be called
-    And "after, finally after" hooks should be called with evaluation details
-      | flag_type | key           | value        |
-      | string    | flag_key      | boolean-flag |
-      | boolean   | value         | true         |
-      | string    | variant       | on           |
-      | string    | reason        | STATIC       |
-      | string    | error_code    | None         |
-      | string    | error_message | None         |
-
   # context-aware evaluation
   Scenario: Resolves based on context
     When context contains keys "fn", "ln", "age", "customer" with values "Sulisław", "Świętopełk", 29, "false"
@@ -70,31 +57,11 @@ Feature: Flag evaluation
 
   # errors
   Scenario: Flag not found
-    When a hook is added to the client
-    And a non-existent string flag with key "missing-flag" is evaluated with details and a default value "uh-oh"
+    When a non-existent string flag with key "missing-flag" is evaluated with details and a default value "uh-oh"
     Then the default string value should be returned
     And the reason should indicate an error and the error code should indicate a missing flag with "FLAG_NOT_FOUND"
-    Then "before, error" hooks should be called
-    And "finally after" hooks should be called with evaluation details
-      | type   | key           | value                         |
-      | string | flag_key      | missing-flag                  |
-      | string | value         | uh-oh                         |
-      | string | variant       | None                          |
-      | string | reason        | ERROR                         |
-      | string | error_code    | ErrorCode.FLAG_NOT_FOUND      |
-      | string | error_message | Flag 'missing-flag' not found |
 
   Scenario: Type error
-    When a hook is added to the client
-    And a string flag with key "wrong-flag" is evaluated as an integer, with details and a default value 13
+    When a string flag with key "wrong-flag" is evaluated as an integer, with details and a default value 13
     Then the default integer value should be returned
     And the reason should indicate an error and the error code should indicate a type mismatch with "TYPE_MISMATCH"
-    Then "before, error" hooks should be called
-    And "finally after" hooks should be called with evaluation details
-      | type    | key           | value                                             |
-      | string  | flag_key      | wrong-flag                                        |
-      | integer | value         | 13                                                |
-      | string  | variant       | None                                              |
-      | string  | reason        | ERROR                                             |
-      | string  | error_code    | ErrorCode.TYPE_MISMATCH                           |
-      | string  | error_message | Expected type <class 'int'> but got <class 'str'> |

--- a/specification/assets/gherkin/hooks.feature
+++ b/specification/assets/gherkin/hooks.feature
@@ -4,14 +4,14 @@ Feature: Evaluation details through hooks
 # This test suite contains scenarios to test the functionality of hooks.
 
   Background:
-    Given a provider is registered with cache disabled
+    Given a stable provider
 
   Scenario: Passes evaluation details to after and finally hooks
     Given a client with added hook
     And a boolean-flag with key "boolean-flag" and a default value "false"
     When the flag was evaluated with details
-    Then "before" hooks should be called
-    And "after, finally after" hooks should be called with evaluation details
+    Then the "before" hook should have been executed
+    And the "after, finally after" hooks should be called with evaluation details
       | data_type | key           | value        |
       | string    | flag_key      | boolean-flag |
       | boolean   | value         | true         |
@@ -25,9 +25,9 @@ Feature: Evaluation details through hooks
     Given a client with added hook
     And a string-flag with key "missing-flag" and a default value "uh-oh"
     When the flag was evaluated with details
-    Then "before" hooks should be called
-    And "error" hooks should be called
-    And "finally after" hooks should be called with evaluation details
+    Then the "before" hook should have been executed
+    And the "error" hook should have been executed
+    And the "finally after" hooks should be called with evaluation details
       | data_type | key           | value                         |
       | string    | flag_key      | missing-flag                  |
       | string    | value         | uh-oh                         |
@@ -40,9 +40,9 @@ Feature: Evaluation details through hooks
     Given a client with added hook
     And a string-flag with key "wrong-flag" and a default value "13"
     When the flag was evaluated with details
-    Then "before" hooks should be called
-    And "error" hooks should be called
-    And "finally after" hooks should be called with evaluation details
+    Then the "before" hook should have been executed
+    And the "error" hook should have been executed
+    And the "finally after" hooks should be called with evaluation details
       | data_type | key           | value                                             |
       | string    | flag_key      | wrong-flag                                        |
       | integer   | value         | 13                                                |

--- a/specification/assets/gherkin/hooks.feature
+++ b/specification/assets/gherkin/hooks.feature
@@ -11,7 +11,7 @@ Feature: Evaluation details through hooks
     And a boolean-flag with key "boolean-flag" and a default value "false"
     When the flag was evaluated with details
     Then the "before" hook should have been executed
-    And the "after, finally after" hooks should be called with evaluation details
+    And the "after, finally" hooks should be called with evaluation details
       | data_type | key           | value        |
       | string    | flag_key      | boolean-flag |
       | boolean   | value         | true         |
@@ -26,7 +26,7 @@ Feature: Evaluation details through hooks
     When the flag was evaluated with details
     Then the "before" hook should have been executed
     And the "error" hook should have been executed
-    And the "finally after" hooks should be called with evaluation details
+    And the "finally" hooks should be called with evaluation details
       | data_type | key           | value                         |
       | string    | flag_key      | missing-flag                  |
       | string    | value         | uh-oh                         |
@@ -40,7 +40,7 @@ Feature: Evaluation details through hooks
     When the flag was evaluated with details
     Then the "before" hook should have been executed
     And the "error" hook should have been executed
-    And the "finally after" hooks should be called with evaluation details
+    And the "finally" hooks should be called with evaluation details
       | data_type | key           | value                                             |
       | string    | flag_key      | wrong-flag                                        |
       | integer   | value         | 13                                                |

--- a/specification/assets/gherkin/hooks.feature
+++ b/specification/assets/gherkin/hooks.feature
@@ -1,0 +1,52 @@
+@hooks
+Feature: Evaluation details through hooks
+
+# This test suite contains scenarios to test the functionality of hooks.
+
+  Background:
+    Given a provider is registered with cache disabled
+
+  Scenario: Passes evaluation details to after and finally hooks
+    Given a client with added hook
+    And a boolean-flag with key "boolean-flag" and a default value "false"
+    When the flag was evaluated with details
+    Then "before" hooks should be called
+    And "after, finally after" hooks should be called with evaluation details
+      | data_type | key           | value        |
+      | string    | flag_key      | boolean-flag |
+      | boolean   | value         | true         |
+      | string    | variant       | on           |
+      | string    | reason        | STATIC       |
+      | string    | error_code    | None         |
+      | string    | error_message | None         |
+
+  # errors
+  Scenario: Flag not found
+    Given a client with added hook
+    And a string-flag with key "missing-flag" and a default value "uh-oh"
+    When the flag was evaluated with details
+    Then "before" hooks should be called
+    And "error" hooks should be called
+    And "finally after" hooks should be called with evaluation details
+      | data_type | key           | value                         |
+      | string    | flag_key      | missing-flag                  |
+      | string    | value         | uh-oh                         |
+      | string    | variant       | None                          |
+      | string    | reason        | ERROR                         |
+      | string    | error_code    | ErrorCode.FLAG_NOT_FOUND      |
+      | string    | error_message | Flag 'missing-flag' not found |
+
+  Scenario: Type error
+    Given a client with added hook
+    And a string-flag with key "wrong-flag" and a default value "13"
+    When the flag was evaluated with details
+    Then "before" hooks should be called
+    And "error" hooks should be called
+    And "finally after" hooks should be called with evaluation details
+      | data_type | key           | value                                             |
+      | string    | flag_key      | wrong-flag                                        |
+      | integer   | value         | 13                                                |
+      | string    | variant       | None                                              |
+      | string    | reason        | ERROR                                             |
+      | string    | error_code    | ErrorCode.TYPE_MISMATCH                           |
+      | string    | error_message | Expected type <class 'int'> but got <class 'str'> |

--- a/specification/assets/gherkin/hooks.feature
+++ b/specification/assets/gherkin/hooks.feature
@@ -17,7 +17,7 @@ Feature: Evaluation details through hooks
       | boolean   | value      | true         |
       | string    | variant    | on           |
       | string    | reason     | STATIC       |
-      | string    | error_code | None         |
+      | string    | error_code | null         |
 
   # errors
   Scenario: Flag not found

--- a/specification/assets/gherkin/hooks.feature
+++ b/specification/assets/gherkin/hooks.feature
@@ -30,7 +30,7 @@ Feature: Evaluation details through hooks
       | data_type | key        | value          |
       | string    | flag_key   | missing-flag   |
       | string    | value      | uh-oh          |
-      | string    | variant    | None           |
+      | string    | variant    | null           |
       | string    | reason     | ERROR          |
       | string    | error_code | FLAG_NOT_FOUND |
 
@@ -44,6 +44,6 @@ Feature: Evaluation details through hooks
       | data_type | key        | value         |
       | string    | flag_key   | wrong-flag    |
       | integer   | value      | 13            |
-      | string    | variant    | None          |
+      | string    | variant    | null          |
       | string    | reason     | ERROR         |
       | string    | error_code | TYPE_MISMATCH |

--- a/specification/assets/gherkin/hooks.feature
+++ b/specification/assets/gherkin/hooks.feature
@@ -12,12 +12,12 @@ Feature: Evaluation details through hooks
     When the flag was evaluated with details
     Then the "before" hook should have been executed
     And the "after, finally" hooks should be called with evaluation details
-      | data_type | key           | value        |
-      | string    | flag_key      | boolean-flag |
-      | boolean   | value         | true         |
-      | string    | variant       | on           |
-      | string    | reason        | STATIC       |
-      | string    | error_code    | None         |
+      | data_type | key        | value        |
+      | string    | flag_key   | boolean-flag |
+      | boolean   | value      | true         |
+      | string    | variant    | on           |
+      | string    | reason     | STATIC       |
+      | string    | error_code | None         |
 
   # errors
   Scenario: Flag not found
@@ -27,12 +27,12 @@ Feature: Evaluation details through hooks
     Then the "before" hook should have been executed
     And the "error" hook should have been executed
     And the "finally" hooks should be called with evaluation details
-      | data_type | key           | value                         |
-      | string    | flag_key      | missing-flag                  |
-      | string    | value         | uh-oh                         |
-      | string    | variant       | None                          |
-      | string    | reason        | ERROR                         |
-      | string    | error_code    | ErrorCode.FLAG_NOT_FOUND      |
+      | data_type | key        | value          |
+      | string    | flag_key   | missing-flag   |
+      | string    | value      | uh-oh          |
+      | string    | variant    | None           |
+      | string    | reason     | ERROR          |
+      | string    | error_code | FLAG_NOT_FOUND |
 
   Scenario: Type error
     Given a client with added hook
@@ -41,9 +41,9 @@ Feature: Evaluation details through hooks
     Then the "before" hook should have been executed
     And the "error" hook should have been executed
     And the "finally" hooks should be called with evaluation details
-      | data_type | key           | value                                             |
-      | string    | flag_key      | wrong-flag                                        |
-      | integer   | value         | 13                                                |
-      | string    | variant       | None                                              |
-      | string    | reason        | ERROR                                             |
-      | string    | error_code    | ErrorCode.TYPE_MISMATCH                           |
+      | data_type | key        | value         |
+      | string    | flag_key   | wrong-flag    |
+      | integer   | value      | 13            |
+      | string    | variant    | None          |
+      | string    | reason     | ERROR         |
+      | string    | error_code | TYPE_MISMATCH |

--- a/specification/assets/gherkin/hooks.feature
+++ b/specification/assets/gherkin/hooks.feature
@@ -18,7 +18,6 @@ Feature: Evaluation details through hooks
       | string    | variant       | on           |
       | string    | reason        | STATIC       |
       | string    | error_code    | None         |
-      | string    | error_message | None         |
 
   # errors
   Scenario: Flag not found
@@ -34,7 +33,6 @@ Feature: Evaluation details through hooks
       | string    | variant       | None                          |
       | string    | reason        | ERROR                         |
       | string    | error_code    | ErrorCode.FLAG_NOT_FOUND      |
-      | string    | error_message | Flag 'missing-flag' not found |
 
   Scenario: Type error
     Given a client with added hook
@@ -49,4 +47,3 @@ Feature: Evaluation details through hooks
       | string    | variant       | None                                              |
       | string    | reason        | ERROR                                             |
       | string    | error_code    | ErrorCode.TYPE_MISMATCH                           |
-      | string    | error_message | Expected type <class 'int'> but got <class 'str'> |


### PR DESCRIPTION
## This PR
Adds gherkin tests to verify the evaluation details passed to the finally hooks

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Part of [https://github.com/open-feature/.github/issues/65](https://github.com/open-feature/.github/issues/65), [https://github.com/open-feature/php-sdk/issues/140](https://github.com/open-feature/php-sdk/issues/140), [https://github.com/open-feature/python-sdk/issues/403](https://github.com/open-feature/python-sdk/issues/403), [https://github.com/open-feature/dotnet-sdk/issues/328](https://github.com/open-feature/dotnet-sdk/issues/328), [https://github.com/open-feature/java-sdk/issues/1246](https://github.com/open-feature/java-sdk/issues/1246), and [https://github.com/open-feature/js-sdk/issues/1109](https://github.com/open-feature/js-sdk/issues/1109)

### Follow-up Tasks
Implement the test steps in the repos
