### PR TITLE
fix(docs): change tracking code example to use proper java syntax

### DIFF
--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -281,7 +281,9 @@ class MyProvider implements Tracking {
   /**
    * Record a tracking event.
    */
-  void track(String trackingEventName, EvaluationContext context, TrackingEventDetails details): void;
+  public void track(String trackingEventName, EvaluationContext context, TrackingEventDetails details) {
+    // perform side effects to record the event
+  }
   
   //...
 }


### PR DESCRIPTION
## This PR
just fixes the java syntax in the providers tracking code example