### PR TITLE
fix: Clarify scenario descriptions in context merging feature

### DIFF
--- a/specification/assets/gherkin/contextMerging.feature
+++ b/specification/assets/gherkin/contextMerging.feature
@@ -34,7 +34,7 @@ Feature: Context merging precedence
       | Before Hooks |
 
   @transaction
-  Scenario: A context entry is added to each level with different keys
+  Scenario: For a transaction, a context entry is added to each level with different keys
     Given A context entry with key "API" and value "API value" is added to the "API" level
     And A context entry with key "Transaction" and value "Transaction value" is added to the "Transaction" level
     And A context entry with key "Client" and value "Client value" is added to the "Client" level
@@ -46,7 +46,7 @@ Feature: Context merging precedence
     And The merged context contains an entry with key "Invocation" and value "Invocation value"
 
   @hooks
-  Scenario: A context entry is added to each level with different keys
+  Scenario: For a hook, a context entry is added to each level with different keys
     Given A context entry with key "API" and value "API value" is added to the "API" level
     And A context entry with key "Client" and value "Client value" is added to the "Client" level
     And A context entry with key "Invocation" and value "Invocation value" is added to the "Invocation" level
@@ -58,7 +58,7 @@ Feature: Context merging precedence
     And The merged context contains an entry with key "Before Hooks" and value "Before Hooks value"
 
   @hooks @transaction
-  Scenario: A context entry is added to each level with different keys
+  Scenario: For a transaction and a hook, a context entry is added to each level with different keys
     Given A context entry with key "API" and value "API value" is added to the "API" level
     And A context entry with key "Transaction" and value "Transaction value" is added to the "Transaction" level
     And A context entry with key "Client" and value "Client value" is added to the "Client" level
@@ -72,7 +72,7 @@ Feature: Context merging precedence
     And The merged context contains an entry with key "Before Hooks" and value "Before Hooks value"
 
   @transaction
-  Scenario Outline: A context entry in one level overwrites values with the same key from preceding levels
+  Scenario Outline: For a transaction, a context entry in one level overwrites values with the same key from preceding levels
     Given A table with levels of increasing precedence
       | API         |
       | Transaction |
@@ -90,7 +90,7 @@ Feature: Context merging precedence
       | Invocation  |
 
   @hooks
-  Scenario Outline: A context entry in one level overwrites values with the same key from preceding levels
+  Scenario Outline: For a hook, a context entry in one level overwrites values with the same key from preceding levels
     Given A table with levels of increasing precedence
       | API          |
       | Client       |
@@ -108,7 +108,7 @@ Feature: Context merging precedence
       | Before Hooks |
 
   @hooks @transaction
-  Scenario Outline: A context entry in one level overwrites values with the same key from preceding levels
+  Scenario Outline: For a transaction and a hook, context entry in one level overwrites values with the same key from preceding levels
     Given A table with levels of increasing precedence
       | API          |
       | Transaction  |


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request includes updates to the `specification/assets/gherkin/contextMerging.feature` file to improve the clarity of scenario descriptions by specifying the context (transaction, hook, or both) in which the context entries are added or overwritten.

Changes to scenario descriptions:

* Updated the scenario description to specify that the context entry is added for a transaction.
* Updated the scenario description to specify that the context entry is added for a hook.
* Updated the scenario description to specify that the context entry is added for both a transaction and a hook.
* Updated the scenario outline description to specify that the context entry overwrites values for a transaction.
* Updated the scenario outline description to specify that the context entry overwrites values for a hook.
* Updated the scenario outline description to specify that the context entry overwrites values for both a transaction and a hook.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #303
