### PR TITLE
fix: Broaden definition of hook data value types.

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -928,7 +928,7 @@
         {
             "id": "Requirement 4.6.1",
             "machine_id": "requirement_4_6_1",
-            "content": "`hook data` MUST be a structure supporting the definition of arbitrary properties, with keys of type `string`, and values of type `boolean | string | number | datetime | structure`.",
+            "content": "`hook data` MUST be a structure supporting the definition of arbitrary properties, with keys of type `string`, and values of any type.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },

--- a/specification/sections/04-hooks.md
+++ b/specification/sections/04-hooks.md
@@ -330,4 +330,11 @@ but different hooks have different hook data instances.
 
 #### Requirement 4.6.1
 
-> `hook data` **MUST** be a structure supporting the definition of arbitrary properties, with keys of type `string`, and values of type `boolean | string | number | datetime | structure`.
+> `hook data` **MUST** be a structure supporting the definition of arbitrary properties, with keys of type `string`, and values of any type.
+
+Access to hook data is restricted to only a single hook instance, and it has no serialization requirements, and as a result does not require any value type restrictions.
+
+Example TypeScript definition:
+```JavaScript
+type HookData = Record<string, unknown>;
+```


### PR DESCRIPTION
## This PR
Loosens the value definition for hook data.

In the example within the spec, and within the implementation in the dotnet-sdk, the intent was to allow any type of data. For example creating an open telemetry span in before, storing it hook data, and ending it in after.

### Notes
Related to: https://github.com/open-feature/dotnet-sdk/pull/387

