### PR TITLE
Add a codeowner, set TSC as the spec owner.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/specification/ @open-feature/technical-steering-committee


### PR DESCRIPTION
This will add the technical steering committee members to new spec PRs.