### PR TITLE
fix: correct shutdown points after status removal

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -352,6 +352,13 @@
             "children": []
         },
         {
+            "id": "Requirement 1.7.9",
+            "machine_id": "requirement_1_7_9",
+            "content": "The client's `provider status` accessor MUST indicate `NOT_READY` once the `shutdown` function of the associated provider terminates.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
             "id": "Requirement 2.1.1",
             "machine_id": "requirement_2_1_1",
             "content": "The provider interface MUST define a `metadata` member or accessor, containing a `name` field or accessor of type string, which identifies the provider implementation.",
@@ -497,8 +504,8 @@
         {
             "id": "Requirement 2.5.2",
             "machine_id": "requirement_2_5_2",
-            "content": "After a provider's shutdown function has terminated successfully, the provider's state MUST revert to its uninitialized state.",
-            "RFC 2119 keyword": "MUST",
+            "content": "After a provider's shutdown function has terminated, the provider SHOULD revert to its uninitialized state.",
+            "RFC 2119 keyword": "SHOULD",
             "children": []
         },
         {

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -513,3 +513,9 @@ see: [error codes](../types.md#error-code), [flag value resolution](./02-provide
 The SDK ensures that if the provider's lifecycle methods terminate with an `error code`, that error code is included in any associated error events and returned/thrown errors/exceptions.
 
 see: [error codes](../types.md#error-code)
+
+#### Requirement 1.7.9
+
+> The client's `provider status` accessor **MUST** indicate `NOT_READY` once the `shutdown` function of the associated provider terminates.
+
+Regardless of the success of the provider's `shutdown` function, the `provider status` should convey the provider is no longer ready to use once the shutdown function terminates.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -225,9 +225,10 @@ class MyProvider implements Provider, AutoDisposable {
 
 #### Requirement 2.5.2
 
-> After a provider's shutdown function has terminated successfully, the provider's state **MUST** revert to its uninitialized state.
+> After a provider's shutdown function has terminated, the provider **SHOULD** revert to its uninitialized state.
 
-If a provider requires initialization, once it's shut down, it must transition to its initial `NOT_READY` state. Some providers may allow reinitialization from this state.
+If a provider requires initialization, once it's shut down, it must transition to its uninitialized state.
+Some providers may allow reinitialization from this state.
 Providers not requiring initialization are assumed to be ready at all times.
 
 see: [initialization](#24-initialization)


### PR DESCRIPTION
This is a minor point of clarification with no material changes.

When we removed `status` from the providers, we didn't migrate this point to the evaluation API, as @fabriziodemaria pointed out [here](https://github.com/open-feature/spec/issues/270).

Fixes: https://github.com/open-feature/spec/issues/270