### PR TITLE
feat: add point 1.6.2, 2.5.3 about shutdown details

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -283,15 +283,15 @@
         {
             "id": "Requirement 1.6.1",
             "machine_id": "requirement_1_6_1",
-            "content": "The API MUST define a function to propagate a shutdown request to active providers.",
+            "content": "The API MUST define a function to propagate a shutdown request to all providers.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
             "id": "Requirement 1.6.2",
             "machine_id": "requirement_1_6_2",
-            "content": "The API's `shutdown` function MUST NOT call shutdown on providers which are in state `NOT_READY`.",
-            "RFC 2119 keyword": "MUST NOT",
+            "content": "The API's `shutdown` function MUST reset all state of the API, removing all hooks, event handlers, and providers.",
+            "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
@@ -511,7 +511,14 @@
         {
             "id": "Requirement 2.5.2",
             "machine_id": "requirement_2_5_2",
-            "content": "After a provider's shutdown function has terminated, the provider SHOULD revert to its uninitialized state.",
+            "content": "After a provider's `shutdown` function has terminated, the provider SHOULD revert to its uninitialized state.",
+            "RFC 2119 keyword": "SHOULD",
+            "children": []
+        },
+        {
+            "id": "Requirement 2.5.3",
+            "machine_id": "requirement_2_5_3",
+            "content": "A Provider's `shutdown` function SHOULD be idempotent.",
             "RFC 2119 keyword": "SHOULD",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -283,8 +283,15 @@
         {
             "id": "Requirement 1.6.1",
             "machine_id": "requirement_1_6_1",
-            "content": "The API MUST define a mechanism to propagate a shutdown request to active providers.",
+            "content": "The API MUST define a function to propagate a shutdown request to active providers.",
             "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
+            "id": "Requirement 1.6.2",
+            "machine_id": "requirement_1_6_2",
+            "content": "The API's `shutdown` function MUST NOT call shutdown on providers which are in state `NOT_READY`.",
+            "RFC 2119 keyword": "MUST NOT",
             "children": []
         },
         {

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -407,7 +407,7 @@ It's recommended that application-authors call this function on application shut
 
 > The API **MUST** define a function to propagate a shutdown request to all providers.
 
-The global API object defines a `shutdown` function, which will call the respective `shutdown` function on the active providers.
+The global API object defines a `shutdown` function, which will call the respective `shutdown` function on all providers.
 Alternatively, implementations might leverage language idioms such as auto-disposable interfaces or some means of cancellation signal propagation to allow for graceful shutdown.
 This shutdown function unconditionally calls the shutdown function on all registered providers, regardless of their state. 
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -401,10 +401,19 @@ See [hooks](./04-hooks.md) for details.
 
 #### Requirement 1.6.1
 
-> The API **MUST** define a mechanism to propagate a shutdown request to active providers.
+> The API **MUST** define a function to propagate a shutdown request to active providers.
 
-The global API object might expose a `shutdown` function, which will call the respective `shutdown` function on the registered providers.
+The global API object might expose a `shutdown` function, which will call the respective `shutdown` function on the active providers.
 Alternatively, implementations might leverage language idioms such as auto-disposable interfaces or some means of cancellation signal propagation to allow for graceful shutdown.
+
+see: [`shutdown`](./02-providers.md#25-shutdown)
+
+#### Requirement 1.6.2
+
+> The API's `shutdown` function **MUST NOT** call shutdown on providers which are in state `NOT_READY`.
+
+With respect to the lifecycle of a given active provider, the global API object's `shutdown` function should be idempotent; multiple calls to `shutdown` should result in only a single execution of the provider's `shutdown` function.
+Implementations should take care to await or cancel the initialization of providers if `shutdown` is called while providers are still being initialized, and have yet to transition to `READY` or some other state.
 
 see: [`shutdown`](./02-providers.md#25-shutdown)
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -401,7 +401,7 @@ See [hooks](./04-hooks.md) for details.
 
 The API's `shutdown` function defines a means of graceful shutdown, calling the `shutdown` function on all providers, allowing them to flush telemetry, clean up connections, and release any relevant resources.
 It also provides a means of resetting the API object to its default state, removing all hooks, event handlers, providers, and setting a "No-op provider"; this is useful for testing purposes.
-It's recommended that application-authors to call this function on application shutdown, and after the completion of test suites which make use of the SDK.
+It's recommended that application-authors call this function on application shutdown, and after the completion of test suites which make use of the SDK.
 
 #### Requirement 1.6.1
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -399,23 +399,26 @@ See [hooks](./04-hooks.md) for details.
 
 [![experimental](https://img.shields.io/static/v1?label=Status&message=experimental&color=orange)](https://github.com/open-feature/spec/tree/main/specification#experimental)
 
+The API's `shutdown` function defines a means of graceful shutdown, calling the `shutdown` function on all providers, allowing them to flush telemetry, clean up connections, and release any relevant resources.
+It also provides a means of resetting the API object to its default state, removing all hooks, event handlers, and providers; this is useful for testing purposes.
+It's recommended that application-authors to call this function on application shutdown, and after the completion of test suites which make use of the SDK.
+
 #### Requirement 1.6.1
 
-> The API **MUST** define a function to propagate a shutdown request to active providers.
+> The API **MUST** define a function to propagate a shutdown request to all providers.
 
-The global API object might expose a `shutdown` function, which will call the respective `shutdown` function on the active providers.
+The global API object defines a `shutdown` function, which will call the respective `shutdown` function on the active providers.
 Alternatively, implementations might leverage language idioms such as auto-disposable interfaces or some means of cancellation signal propagation to allow for graceful shutdown.
+This shutdown function unconditionally calls the shutdown function on all registered providers, regardless of their state. 
 
 see: [`shutdown`](./02-providers.md#25-shutdown)
 
 #### Requirement 1.6.2
 
-> The API's `shutdown` function **MUST NOT** call shutdown on providers which are in state `NOT_READY`.
+> The API's `shutdown` function **MUST** reset all state of the API, removing all hooks, event handlers, and providers.
 
-With respect to the lifecycle of a given active provider, the global API object's `shutdown` function should be idempotent; multiple calls to `shutdown` should result in only a single execution of the provider's `shutdown` function.
-Implementations should take care to await or cancel the initialization of providers if `shutdown` is called while providers are still being initialized, and have yet to transition to `READY` or some other state.
-
-see: [`shutdown`](./02-providers.md#25-shutdown)
+After shutting down all providers, the `shutdown` function resets the state of the API.
+This is especially useful for testing purposes to restore the API to a known state.
 
 ### 1.7. Provider Lifecycle Management
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -400,7 +400,7 @@ See [hooks](./04-hooks.md) for details.
 [![experimental](https://img.shields.io/static/v1?label=Status&message=experimental&color=orange)](https://github.com/open-feature/spec/tree/main/specification#experimental)
 
 The API's `shutdown` function defines a means of graceful shutdown, calling the `shutdown` function on all providers, allowing them to flush telemetry, clean up connections, and release any relevant resources.
-It also provides a means of resetting the API object to its default state, removing all hooks, event handlers, and providers; this is useful for testing purposes.
+It also provides a means of resetting the API object to its default state, removing all hooks, event handlers, providers, and setting a "No-op provider"; this is useful for testing purposes.
 It's recommended that application-authors to call this function on application shutdown, and after the completion of test suites which make use of the SDK.
 
 #### Requirement 1.6.1

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -225,11 +225,20 @@ class MyProvider implements Provider, AutoDisposable {
 
 #### Requirement 2.5.2
 
-> After a provider's shutdown function has terminated, the provider **SHOULD** revert to its uninitialized state.
+> After a provider's `shutdown` function has terminated, the provider **SHOULD** revert to its uninitialized state.
 
 If a provider requires initialization, once it's shut down, it must transition to its uninitialized state.
 Some providers may allow reinitialization from this state.
 Providers not requiring initialization are assumed to be ready at all times.
+Providers in the process of initializing abort initialization if shutdown is called while they are still starting up.
+
+see: [initialization](#24-initialization)
+
+#### Requirement 2.5.3
+
+> A Provider's `shutdown` function **SHOULD** be idempotent.
+
+If a provider's `shutdown` function has been called, subsequent calls (without an intervening call to `initialize`) should have no effect.
 
 see: [initialization](#24-initialization)
 


### PR DESCRIPTION
This is a change that I suspect will have little practical impact for most users, but helps disambiguate some behavior that recently caused [issues](https://github.com/open-feature/go-sdk/issues/397) and [confusion](https://github.com/open-feature/go-sdk/pull/400/files#r2191214490).

This is only one means of addressing this concern, so please don't hesitate to put forward alternative proposals.

"Idempotent" may not be exactly the right word here, since it's only idempotent within the scope of one execution of the life-cycle, so I'm open to copy changes here as well.

# EDIT

:warning: I've substantially changed this PR based on feedback, and dismissed all approvals:

As @erka and others have pointed out, practically, `shutdown` has been used for more than just cleaning up providers, it's also used frequently to "reset" the API for testing purposes. I think this is a valid use-case and I don't see any reason why it can't be added to what (at least my understanding of) the original intent of the function was... so I've changed 1.6.2 to say that the `shutdown` now also resets the state of the API fully (removes hooks, providers, event handlers, etc) from the API.

As @chrfwow noted (and I was concerned about as well) guaranteeing that `shutdown` is not called while a provider is still starting up will be tricky to implement. Instead I've changed 1.6.1 to say we will unconditionally run shutdown on all providers, and also added a recommendation that providers handle this gracefully in the provider spec.

@sahidvelji I've also added a pre-amble about shutdown in general as you requested.

@lukas-reining @erka @beeme1mr @sahidvelji @chrfwow  please re-review.