### PR TITLE
docs: clarify evaluation context in hook requirements

### DIFF
--- a/specification/sections/04-hooks.md
+++ b/specification/sections/04-hooks.md
@@ -49,6 +49,8 @@ Hook context exists to provide hooks with information about the invocation and p
 
 > Hook context **MUST** provide: the `flag key`, `flag value type`, `evaluation context`, `default value`, and `hook data`.
 
+The `evaluation context` provided in the hook context refers to the **merged evaluation context** as specified in [Requirement 3.2.3](./03-evaluation-context.md#requirement-323).
+
 #### Requirement 4.1.2
 
 > The `hook context` **SHOULD** provide access to the `client metadata` and the `provider metadata` fields.


### PR DESCRIPTION
## This PR

- clarify evaluation context in hook requirements

### Related Issues

Fixes #328

### Notes

I added the clarification in the non-normative section. Hopefully, this addresses the ambiguity around what we mean by `evaluation context`.
