### PR TITLE
add telemetry hook implementation guidelines

### DIFF
--- a/specification/appendix-d-observability.md
+++ b/specification/appendix-d-observability.md
@@ -98,7 +98,7 @@ For consistency across implementations, consider supporting a common set of conf
 
 - `attributeMapper` (function): Custom function to add additional attributes to the signal
 - `excludeAttributes` (list): List of attribute keys to exclude from the signal
-- `excludeExceptions` (boolean): Whether to omit [exception details][otel-exception-details] from error signals using
+- `excludeExceptions` (boolean): Whether to omit [exception details][otel-exception-details] from error signals
 - `eventMutator` (function): Custom function to modify event attributes before sending
 
 ### Error Handling


### PR DESCRIPTION
## This PR

- adds observability hook guidelines to the appendix

### Notes

This is based on the [updated telemetry hook](https://github.com/open-feature/js-sdk-contrib/pull/1372) @lukas-reining wrote. I tried to capture as much context as possible so that other maintainers can understand how the hook should be written.

Since this is in the appendix section, I decided to make the guide human-readable instead of just a list of requirements.

### Follow-up Tasks

Create implementation issues for all SDKs based on these guidelines.
