### PR TITLE
docs: clarify evaluation and resolution details

### DIFF
--- a/specification/types.md
+++ b/specification/types.md
@@ -32,7 +32,7 @@ A language primitive for representing a date and time, optionally including time
 
 ### Evaluation Details
 
-A structure representing the result of the [flag evaluation process](./glossary.md#evaluating-flag-values), and made available in the [detailed flag resolution functions](./sections/01-flag-evaluation.md#14-detailed-flag-evaluation), containing the following fields:
+A structure representing the result of the [flag evaluation process](./glossary.md#evaluating-flag-values), and made available in the [detailed flag evaluation functions](./sections/01-flag-evaluation.md#14-detailed-flag-evaluation), containing the following fields:
 
 - flag key (string, required)
 - value (boolean | string | number | structure, required)
@@ -44,6 +44,10 @@ A structure representing the result of the [flag evaluation process](./glossary.
 
 > [!NOTE]  
 > Some type systems feature useful constraints that can enhance the ergonomics of the `evaluation details` structure. For example, in the case of an unsuccessful evaluation, `error code`, `reason`, and `error message` will be set, and `variant` will not. If the type system of the implementation supports the expression of such constraints, consider defining them.
+
+> [!NOTE]
+> `evaluation details` are the application-facing result returned from detailed flag evaluation.
+> They include the `flag key` supplied to the client, the evaluated value, and other fields derived from the provider's `resolution details` when available, such as `variant`, `reason`, `error code`, `error message`, and `flag metadata`.
 
 ### Resolution Details
 
@@ -91,7 +95,10 @@ enum Reason {
 let myReason = Reason::Other("my-reason".to_string());
 ```
 
-> [!NOTE] The `resolution details` structure is not exposed to the Application Author. It defines the data which Provider Authors must return when resolving the value of flags.
+> [!NOTE]
+> `resolution details` are the return structure providers send to the SDK.
+> Provider Authors return this structure when resolving a flag value.
+> Application Authors do not receive the actual `resolution details` object directly; instead, detailed flag evaluation functions return an `evaluation details` object built from the provider's `resolution details` when available, plus SDK-level fields such as `flag key`, default values, and error information.
 
 ### Error Code
 


### PR DESCRIPTION
## What changed

Clarifies the relationship between `evaluation details` and `resolution details` in `specification/types.md`.

The update:

- uses “detailed flag evaluation functions” for the application-facing API surface
- describes `evaluation details` as the application-facing result returned from detailed flag evaluation
- describes `resolution details` as the provider-to-SDK return shape used to build evaluation details

## Why

The two structures share many fields, which can make it unclear why both exist. This adds a small docs clarification without changing any requirements or API behavior.

Fixes #168.

## Validation

Ran locally:

```sh
npm ci
python3 ./tools/specification_parser/specification_parser.py
tmpbin=$(mktemp -d) && ln -s "$(command -v python3)" "$tmpbin/python" && PATH="$tmpbin:$PATH" make parse
make markdown-toc
./node_modules/.bin/markdownlint specification/types.md
npx -p node@24 -c './node_modules/.bin/markdown-link-check -c .markdown-link-check-config.json specification/types.md'
tmpbin=$(mktemp -d) && ln -s "$(command -v python3)" "$tmpbin/python" && PATH="$tmpbin:$PATH" npx -p node@24 -c 'make lint'
git diff --check
```
