### PR TITLE
feat: multi-provider strategies skip providers returning reason=DISABLED

### DIFF
--- a/specification/appendix-a-included-utilities.md
+++ b/specification/appendix-a-included-utilities.md
@@ -255,7 +255,7 @@ As soon as a value is returned by a provider, the rest of the operation should s
 #### First Successful Strategy
 
 Similar to "First Match", except that errors from evaluated providers do not halt execution.
-Instead, it will return the first successful result from a provider that has a value (i.e. not `FLAG_NOT_FOUND` or `reason=DISABLED`). If no provider successfully responds with a value, it will throw an error result.
+Instead, it will return the first successful result from a provider that has a value (i.e. not `reason=DISABLED`). If no provider successfully responds with a value, it will throw an error result.
 
 [See the refrence implementation](https://github.com/open-feature/js-sdk-contrib/blob/main/libs/providers/multi-provider/src/lib/strategies/FirstSuccessfulStrategy.ts)
 

--- a/specification/appendix-a-included-utilities.md
+++ b/specification/appendix-a-included-utilities.md
@@ -255,7 +255,7 @@ As soon as a value is returned by a provider, the rest of the operation should s
 #### First Successful Strategy
 
 Similar to "First Match", except that errors from evaluated providers do not halt execution.
-Instead, it will return the first successful result from a provider that has a value (i.e. not `reason=DISABLED`). If no provider successfully responds with a value, it will throw an error result.
+Instead, it will return the first successful result from a provider whose `reason` is not `DISABLED`. If no provider successfully responds, it will throw an error result.
 
 [See the refrence implementation](https://github.com/open-feature/js-sdk-contrib/blob/main/libs/providers/multi-provider/src/lib/strategies/FirstSuccessfulStrategy.ts)
 

--- a/specification/appendix-a-included-utilities.md
+++ b/specification/appendix-a-included-utilities.md
@@ -244,7 +244,7 @@ Here are some standard strategies that come with the Multi-Provider:
 #### First Match Strategy
 
 Return the first result returned by a provider.
-Skip providers that indicate they had no value due to `FLAG_NOT_FOUND`.
+Skip providers that indicate they had no value due to `FLAG_NOT_FOUND`, or that the flag is intentionally disabled (`reason=DISABLED`).
 In all other cases, use the value returned by the provider.
 If any provider returns an error result other than `FLAG_NOT_FOUND`, the whole evaluation should error and "bubble up" the individual provider's error in the result.
 
@@ -255,14 +255,15 @@ As soon as a value is returned by a provider, the rest of the operation should s
 #### First Successful Strategy
 
 Similar to "First Match", except that errors from evaluated providers do not halt execution.
-Instead, it will return the first successful result from a provider. If no provider successfully responds, it will throw an error result.
+Instead, it will return the first successful result from a provider that has a value (i.e. not `FLAG_NOT_FOUND` or `reason=DISABLED`). If no provider successfully responds with a value, it will throw an error result.
 
 [See the refrence implementation](https://github.com/open-feature/js-sdk-contrib/blob/main/libs/providers/multi-provider/src/lib/strategies/FirstSuccessfulStrategy.ts)
 
 #### Comparison Strategy
 
 Require that all providers agree on a value.
-If every provider returns a non-error result, and the values do not agree, the Multi-Provider should return the result from a configurable "fallback" provider.
+Providers that return `FLAG_NOT_FOUND` or `reason=DISABLED` are excluded from the comparison.
+If every remaining provider returns a non-error result, and the values do not agree, the Multi-Provider should return the result from a configurable "fallback" provider.
 It will also call an optional "onMismatch" callback that can be used to monitor cases where mismatches of evaluation occurred.
 Otherwise the value of the result will be the result of the first provider in precedence order.
 


### PR DESCRIPTION
## Summary

`reason=DISABLED` means a provider has intentionally turned a flag off; it's an operational state, not a resolved value. In a Multi-Provider context, this is semantically equivalent to `FLAG_NOT_FOUND` — the provider isn't returning a value, so the Multi-Provider should fall through to the next one.

This is a widespread pattern across the OpenFeature provider ecosystem. Flipt (Go, JS, .NET), Flagsmith (Go, Java, JS, .NET), LaunchDarkly, Optimizely, GO Feature Flag, OFREP, DevCycle, and the Dynatrace providers all return `reason=DISABLED` when a flag is intentionally off.

This PR updates the three standard strategies to treat `reason=DISABLED` consistently as a fall-through signal, the same as `FLAG_NOT_FOUND`:

- **First Match**: also skips providers returning `reason=DISABLED`
- **First Successful**: also skips providers returning `reason=DISABLED` when looking for a provider with a value
- **Comparison**: excludes providers returning `reason=DISABLED` from the comparison

The immediate trigger for this change is the [flagd disabled flag evaluation ADR](https://github.com/open-feature/flagd/blob/main/docs/architecture-decisions/disabled-flag-evaluation.md), which moves flagd from returning a `FLAG_DISABLED` error to a successful `reason=DISABLED` result. Without this spec update, that change would silently break Multi-Provider fall-through for flagd users.