### PR TITLE
feat: setup publishing for repo parser to GHCR

### DIFF
--- a/.github/workflows/publish-repo-parser.yaml
+++ b/.github/workflows/publish-repo-parser.yaml
@@ -1,0 +1,47 @@
+name: Publish repo_parser image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - tools/repo_parser/**
+
+permissions: {}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/repo_parser
+
+jobs:
+  build-and-push:
+    name: Build and push Docker image to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4.2.0 # Immutable tag - https://github.com/docker/login-action/releases/tag/v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6.1.0 # Immutable tag - https://github.com/docker/metadata-action/releases/tag/v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v7.2.0 # Immutable tag - https://github.com/docker/build-push-action/releases/tag/v7.2.0
+        with:
+          context: tools/repo_parser
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/tools/repo_parser/Dockerfile
+++ b/tools/repo_parser/Dockerfile
@@ -1,4 +1,11 @@
-FROM cgr.dev/chainguard/python:latest
+FROM python:3.14-slim
+
+LABEL org.opencontainers.image.title="repo_parser" \
+      org.opencontainers.image.description="Parses OpenFeature SDK repos and reports spec compliance coverage" \
+      org.opencontainers.image.source="https://github.com/open-feature/spec" \
+      org.opencontainers.image.url="https://github.com/open-feature/spec/tree/main/tools/repo_parser" \
+      org.opencontainers.image.vendor="OpenFeature" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 WORKDIR .
 

--- a/tools/repo_parser/pyproject.toml
+++ b/tools/repo_parser/pyproject.toml
@@ -6,7 +6,7 @@ strict = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py312"
+target-version = "py314"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## This PR
- Sets up publishing of the repo_parser tool to the GHCR to then make a github action to test repos as per @beeme1mr's idea.
- Moves to generic python image instead of the licensed chainguard image. 
- Updates tool to Python 3.14 to be actively supported over 3.12
### Related Issues

Closes #258 


### Follow-up Tasks

Will be creating a stacked PR to make a sourced github action from this repo to test downstream repos for spec compliance.



For a refresher, the repo_parser/spec_finder tools match test case descriptions to the spec definitions.

> We look for a `.specrc` file in the root of a repository to figure out how to find test cases that are annotated with
> the spec number and the text of the spec. We can then produce a report which says "you're covered" or details 
> about how you're not covered. The goal of this is to use that resulting report to power a spec-compliance matrix 
> for end users to vet SDK quality.
