### PR TITLE
feat: supply the bound domain to provider initialization

### DIFF
--- a/specification.json
+++ b/specification.json
@@ -17,7 +17,7 @@
         {
             "id": "Requirement 1.1.2.2",
             "machine_id": "requirement_1_1_2_2",
-            "content": "The `provider mutator` function MUST invoke the `initialize` function on the newly registered provider before using it to resolve flag values, supplying the global `evaluation context` and the `domain` the provider is being registered under, if any.",
+            "content": "The `provider mutator` function MUST invoke the `initialize` function on the newly registered provider before using it to resolve flag values, supplying the bound `domain`, if any.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -17,7 +17,7 @@
         {
             "id": "Requirement 1.1.2.2",
             "machine_id": "requirement_1_1_2_2",
-            "content": "The `provider mutator` function MUST invoke the `initialize` function on the newly registered provider before using it to resolve flag values.",
+            "content": "The `provider mutator` function MUST invoke the `initialize` function on the newly registered provider before using it to resolve flag values, supplying the global `evaluation context` and the `domain` the provider is being registered under, if any.",
             "RFC 2119 keyword": "MUST",
             "children": []
         },
@@ -33,13 +33,6 @@
             "machine_id": "requirement_1_1_2_4",
             "content": "The `API` SHOULD provide functions to set a provider and wait for the `initialize` function to complete or abnormally terminate.",
             "RFC 2119 keyword": "SHOULD",
-            "children": []
-        },
-        {
-            "id": "Requirement 1.1.2.5",
-            "machine_id": "requirement_1_1_2_5",
-            "content": "When the `provider mutator` invokes a provider's `initialize` function, the `API` MUST supply the `domain` the provider is being registered under, if any.",
-            "RFC 2119 keyword": "MUST",
             "children": []
         },
         {
@@ -517,7 +510,7 @@
         {
             "id": "Requirement 2.4.1",
             "machine_id": "requirement_2_4_1",
-            "content": "The `provider` MAY define an initialization function which accepts the global `evaluation context` as an argument and performs initialization logic relevant to the provider.",
+            "content": "The `provider` MAY define an initialization function which accepts the global `evaluation context` and the bound `domain` (if any) as arguments and performs initialization logic relevant to the provider.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },
@@ -535,13 +528,6 @@
                     "children": []
                 }
             ]
-        },
-        {
-            "id": "Requirement 2.4.3",
-            "machine_id": "requirement_2_4_3",
-            "content": "The `provider` MAY define an initialization function which additionally accepts the `domain` it is registered under, if any.",
-            "RFC 2119 keyword": "MAY",
-            "children": []
         },
         {
             "id": "Requirement 2.5.1",

--- a/specification.json
+++ b/specification.json
@@ -525,7 +525,7 @@
         {
             "id": "Requirement 2.4.1",
             "machine_id": "requirement_2_4_1",
-            "content": "The `provider` MAY define an initialization function which accepts the global `evaluation context` and, optionally, the bound `domain` (if any), and performs initialization logic relevant to the provider.",
+            "content": "The `provider` MAY define an initialization function which accepts the global `evaluation context` and an optional bound `domain`, which performs initialization logic relevant to the provider.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -525,7 +525,7 @@
         {
             "id": "Requirement 2.4.1",
             "machine_id": "requirement_2_4_1",
-            "content": "The `provider` MAY define an initialization function which accepts the global `evaluation context` and the bound `domain` (if any) as arguments and performs initialization logic relevant to the provider.",
+            "content": "The `provider` MAY define an initialization function which accepts the global `evaluation context` and, optionally, the bound `domain` (if any), and performs initialization logic relevant to the provider.",
             "RFC 2119 keyword": "MAY",
             "children": []
         },

--- a/specification.json
+++ b/specification.json
@@ -71,6 +71,21 @@
             "children": []
         },
         {
+            "id": "Condition 1.1.8",
+            "machine_id": "condition_1_1_8",
+            "content": "The `provider` declares that it is `domain-scoped`.",
+            "RFC 2119 keyword": null,
+            "children": [
+                {
+                    "id": "Conditional Requirement 1.1.8.1",
+                    "machine_id": "conditional_requirement_1_1_8_1",
+                    "content": "The `provider mutator` MUST NOT bind a `domain-scoped` provider instance to more than one `domain`, rejecting any attempt to bind an already-bound instance to an additional `domain`.",
+                    "RFC 2119 keyword": "MUST NOT",
+                    "children": []
+                }
+            ]
+        },
+        {
             "id": "Requirement 1.2.1",
             "machine_id": "requirement_1_2_1",
             "content": "The client MUST provide a method to add `hooks` which accepts one or more API-conformant `hooks`, and appends them to the collection of any previously added hooks. When new hooks are added, previously added hooks are not removed.",
@@ -528,6 +543,13 @@
                     "children": []
                 }
             ]
+        },
+        {
+            "id": "Requirement 2.4.3",
+            "machine_id": "requirement_2_4_3",
+            "content": "The `provider` MAY declare that it is `domain-scoped`, indicating that it maintains state specific to a single `domain`, such as a persistent cache, that cannot be shared across `domains`.",
+            "RFC 2119 keyword": "MAY",
+            "children": []
         },
         {
             "id": "Requirement 2.5.1",

--- a/specification.json
+++ b/specification.json
@@ -36,6 +36,13 @@
             "children": []
         },
         {
+            "id": "Requirement 1.1.2.5",
+            "machine_id": "requirement_1_1_2_5",
+            "content": "When the `provider mutator` invokes a provider's `initialize` function, the `API` MUST supply the `domain` the provider is being registered under, if any.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
             "id": "Requirement 1.1.3",
             "machine_id": "requirement_1_1_3",
             "content": "The `API` MUST provide a function to bind a given `provider` to one or more clients using a `domain`. If the domain already has a bound provider, it is overwritten with the new mapping.",
@@ -528,6 +535,13 @@
                     "children": []
                 }
             ]
+        },
+        {
+            "id": "Requirement 2.4.3",
+            "machine_id": "requirement_2_4_3",
+            "content": "The `provider` MAY define an initialization function which additionally accepts the `domain` it is registered under, if any.",
+            "RFC 2119 keyword": "MAY",
+            "children": []
         },
         {
             "id": "Requirement 2.5.1",

--- a/specification.json
+++ b/specification.json
@@ -552,6 +552,13 @@
             "children": []
         },
         {
+            "id": "Requirement 2.4.4",
+            "machine_id": "requirement_2_4_4",
+            "content": "A `provider` that declares itself `domain-scoped` MUST accept the bound `domain` during initialization.",
+            "RFC 2119 keyword": "MUST",
+            "children": []
+        },
+        {
             "id": "Requirement 2.5.1",
             "machine_id": "requirement_2_5_1",
             "content": "The provider MAY define a mechanism to gracefully shutdown and dispose of resources.",

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -158,7 +158,6 @@ see: [Requirement 2.4.3](./02-providers.md#requirement-243)
 > The `provider mutator` **MUST NOT** bind a `domain-scoped` provider instance to more than one `domain`, rejecting any attempt to bind an already-bound instance to an additional `domain`.
 
 A `domain-scoped` provider keys per-`domain` state on the single `domain` supplied to its `initialize` function.
-Allowing the same instance to back a second `domain` would reintroduce the collision the declaration exists to prevent, so the `API` rejects the binding rather than sharing the instance.
 Rejection should occur in a manner idiomatic to the implementation language (throwing, returning an error, etc.), and leaves any existing binding intact.
 
 ### 1.2. Client Usage

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -147,6 +147,20 @@ See [setting a provider](#setting-a-provider), [domain](../glossary.md#domain) f
 
 Clients may be created in critical code paths, and even per-request in server-side HTTP contexts. Therefore, in keeping with the principle that OpenFeature should never cause abnormal execution of the first party application, this function should never throw. Abnormal execution in initialization should instead occur during provider registration.
 
+#### Condition 1.1.8
+
+> The `provider` declares that it is `domain-scoped`.
+
+see: [Requirement 2.4.3](./02-providers.md#requirement-243)
+
+##### Conditional Requirement 1.1.8.1
+
+> The `provider mutator` **MUST NOT** bind a `domain-scoped` provider instance to more than one `domain`, rejecting any attempt to bind an already-bound instance to an additional `domain`.
+
+A `domain-scoped` provider keys per-`domain` state on the single `domain` supplied to its `initialize` function.
+Allowing the same instance to back a second `domain` would reintroduce the collision the declaration exists to prevent, so the `API` rejects the binding rather than sharing the instance.
+Rejection should occur in a manner idiomatic to the implementation language (throwing, returning an error, etc.), and leaves any existing binding intact.
+
 ### 1.2. Client Usage
 
 #### Requirement 1.2.1
@@ -577,7 +591,7 @@ import { createIsolatedOpenFeatureAPI } from '@openfeature/web-sdk/isolated';
 > A `provider` instance **SHOULD NOT** be registered with more than one `API` instance simultaneously.
 
 Because the `API` instance manages the [lifecycle](./02-providers.md) of its associated providers (including initialization, shutdown, and event handling), binding a `provider` to more than one `API` instance could result in undefined behavior.
-A `provider` instance can be registered with multiple `domains` within a single `API` instance.
+A `provider` instance can be registered with multiple `domains` within a single `API` instance, unless it declares itself `domain-scoped` (see [Requirement 2.4.3](./02-providers.md#requirement-243)), in which case it can be bound to at most one `domain`.
 When a provider is no longer associated with an `API` instance, it can be registered to another. 
 
 See [setting a provider](#setting-a-provider), [domain](../glossary.md#domain) for details.

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -38,7 +38,7 @@ See [provider](./02-providers.md), [creating clients](#creating-clients) for det
 
 #### Requirement 1.1.2.2
 
-> The `provider mutator` function **MUST** invoke the `initialize` function on the newly registered provider before using it to resolve flag values.
+> The `provider mutator` function **MUST** invoke the `initialize` function on the newly registered provider before using it to resolve flag values, supplying the global `evaluation context` and the `domain` the provider is being registered under, if any.
 
 Application authors can await the newly set `provider's` readiness using the `PROVIDER_READY` event.
 Provider instances which are already active (because they have been bound to another `domain` or otherwise) need not be initialized again.
@@ -75,14 +75,6 @@ Client client = OpenFeatureAPI.getInstance().getClient('domain-1');
 
 Though it's possible to use [events](./05-events.md) to await provider readiness, such functions can make things simpler for `application authors` and `integrators`.
 Implementations indicate an error in a manner idiomatic to the language in use (returning an error, throwing an exception, etc).
-
-#### Requirement 1.1.2.5
-
-> When the `provider mutator` invokes a provider's `initialize` function, the `API` **MUST** supply the `domain` the provider is being registered under, if any.
-
-This allows providers to scope domain-specific behavior, such as partitioning a persistent cache, to the `domain` they are bound to.
-
-See [provider initialization](./02-providers.md#24-initialization), [domain](../glossary.md#domain) for details.
 
 #### Requirement 1.1.3
 

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -76,6 +76,14 @@ Client client = OpenFeatureAPI.getInstance().getClient('domain-1');
 Though it's possible to use [events](./05-events.md) to await provider readiness, such functions can make things simpler for `application authors` and `integrators`.
 Implementations indicate an error in a manner idiomatic to the language in use (returning an error, throwing an exception, etc).
 
+#### Requirement 1.1.2.5
+
+> When the `provider mutator` invokes a provider's `initialize` function, the `API` **MUST** supply the `domain` the provider is being registered under, if any.
+
+This allows providers to scope domain-specific behavior, such as partitioning a persistent cache, to the `domain` they are bound to.
+
+See [provider initialization](./02-providers.md#24-initialization), [domain](../glossary.md#domain) for details.
+
 #### Requirement 1.1.3
 
 > The `API` **MUST** provide a function to bind a given `provider` to one or more clients using a `domain`. If the domain already has a bound provider, it is overwritten with the new mapping.

--- a/specification/sections/01-flag-evaluation.md
+++ b/specification/sections/01-flag-evaluation.md
@@ -38,7 +38,7 @@ See [provider](./02-providers.md), [creating clients](#creating-clients) for det
 
 #### Requirement 1.1.2.2
 
-> The `provider mutator` function **MUST** invoke the `initialize` function on the newly registered provider before using it to resolve flag values, supplying the global `evaluation context` and the `domain` the provider is being registered under, if any.
+> The `provider mutator` function **MUST** invoke the `initialize` function on the newly registered provider before using it to resolve flag values, supplying the bound `domain`, if any.
 
 Application authors can await the newly set `provider's` readiness using the `PROVIDER_READY` event.
 Provider instances which are already active (because they have been bound to another `domain` or otherwise) need not be initialized again.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -221,6 +221,13 @@ Most providers are stateless with respect to their `domain` and can safely back 
 Providers that persist or cache `domain`-specific data need a stable, unambiguous `domain` to key that state on.
 By declaring itself `domain-scoped`, such a provider signals that the `API` must bind it to at most one `domain` (see [Requirement 1.1.8](./01-flag-evaluation.md#condition-118)), guaranteeing the `domain` supplied to `initialize` is the only one the instance will ever serve.
 
+#### Requirement 2.4.4
+
+> A `provider` that declares itself `domain-scoped` **MUST** accept the bound `domain` during initialization.
+
+A `domain-scoped` declaration is only meaningful if the provider consumes the `domain` it is given to scope its state.
+This is a contract on the provider; implementations may not be able to detect or reject a violation automatically, so it is not guaranteed to surface as a runtime error.
+
 ### 2.5. Shutdown
 
 [![hardening](https://img.shields.io/static/v1?label=Status&message=hardening&color=yellow)](https://github.com/open-feature/spec/tree/main/specification#hardening)

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -180,16 +180,18 @@ The `domain` the provider is registered under is also supplied, allowing the pro
 A `provider` instance is initialized only once, even when bound to multiple `domains`; in that case the `domain` supplied is the one under which it was first registered.
 The default provider, which is not bound to a domain, is initialized without one.
 
-```typescript
+```java
 // MyProvider implementation of the initialize function defined in Provider
 class MyProvider implements Provider {
   //...
 
   // the global context and the bound domain are passed to the initialization function
-  async initialize(initialContext: EvaluationContext, domain?: string): Promise<void> {
+  void initialize(EvaluationContext initialContext, String domain) {
     this.domain = domain;
-    // A hypothetical initialization function: make an initial call doing some bulk initial evaluation, start a worker to do periodic updates
-    this.flagCache = await this.restClient.bulkEvaluate(initialContext);
+    /*
+      A hypothetical initialization function: make an initial call doing some bulk initial evaluation, start a worker to do periodic updates
+    */
+    this.flagCache = this.restClient.bulkEvaluate(initialContext);
     this.startPolling();
   }
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -178,6 +178,7 @@ The initialization function is an ideal place for such logic.
 
 The `domain` the provider is registered under is also supplied, allowing the provider to scope domain-specific behavior, such as partitioning a persistent cache, so that multiple providers sharing the same storage do not collide.
 A `provider` instance is initialized only once, even when bound to multiple `domains`; in that case the `domain` supplied is the one under which it was first registered.
+A provider that maintains `domain`-specific state can instead declare itself `domain-scoped` (see [Requirement 2.4.3](#requirement-243)), in which case it is restricted to a single `domain` and this ambiguity does not arise.
 The default provider, which is not bound to a domain, is initialized without one.
 
 ```java
@@ -211,6 +212,14 @@ If a provider is unable to start up correctly, it should indicate abnormal execu
 If the error is irrecoverable (perhaps due to bad credentials or invalid configuration) the `PROVIDER_FATAL` error code should be used.
 
 see: [error codes](../types.md#error-code)
+
+#### Requirement 2.4.3
+
+> The `provider` **MAY** declare that it is `domain-scoped`, indicating that it maintains state specific to a single `domain`, such as a persistent cache, that cannot be shared across `domains`.
+
+Most providers are stateless with respect to their `domain` and can safely back multiple `domains` from a single instance.
+Providers that persist or cache `domain`-specific data need a stable, unambiguous `domain` to key that state on.
+By declaring itself `domain-scoped`, such a provider signals that the `API` must bind it to at most one `domain` (see [Requirement 1.1.8](./01-flag-evaluation.md#condition-118)), guaranteeing the `domain` supplied to `initialize` is the only one the instance will ever serve.
 
 ### 2.5. Shutdown
 

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -170,7 +170,7 @@ class MyProvider implements Provider {
 
 #### Requirement 2.4.1
 
-> The `provider` **MAY** define an initialization function which accepts the global `evaluation context` and, optionally, the bound `domain` (if any), and performs initialization logic relevant to the provider.
+> The `provider` **MAY** define an initialization function which accepts the global `evaluation context` and an optional bound `domain`, which performs initialization logic relevant to the provider.
 
 Many feature flag frameworks or SDKs require some initialization before they can be used.
 They might require the completion of an HTTP request, establishing persistent connections, or starting timers or worker threads.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -170,7 +170,7 @@ class MyProvider implements Provider {
 
 #### Requirement 2.4.1
 
-> The `provider` **MAY** define an initialization function which accepts the global `evaluation context` and the bound `domain` (if any) as arguments and performs initialization logic relevant to the provider.
+> The `provider` **MAY** define an initialization function which accepts the global `evaluation context` and, optionally, the bound `domain` (if any), and performs initialization logic relevant to the provider.
 
 Many feature flag frameworks or SDKs require some initialization before they can be used.
 They might require the completion of an HTTP request, establishing persistent connections, or starting timers or worker threads.

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -207,6 +207,26 @@ If the error is irrecoverable (perhaps due to bad credentials or invalid configu
 
 see: [error codes](../types.md#error-code)
 
+#### Requirement 2.4.3
+
+> The `provider` **MAY** define an initialization function which additionally accepts the `domain` it is registered under, if any.
+
+When a provider is bound to a [domain](../glossary.md#domain), it may need to scope behavior to that domain, such as partitioning a persistent cache or labeling telemetry, so that multiple providers sharing the same storage do not collide.
+Supplying the `domain` at initialization mirrors how the global `evaluation context` is supplied (see [Requirement 2.4.1](#requirement-241)).
+
+```java
+class MyProvider implements Provider {
+  // the global context and the bound domain are passed to the initialization function
+  void initialize(EvaluationContext initialContext, String domain) {
+    this.cacheKeyPrefix = domain; // scope persisted state to this domain
+    this.flagCache = this.restClient.bulkEvaluate(initialContext);
+  }
+}
+```
+
+A `provider` instance is initialized only once, even when bound to multiple `domains`; in that case the `domain` supplied is the one under which it was first registered.
+The default provider, which is not bound to a domain, is initialized without one.
+
 ### 2.5. Shutdown
 
 [![hardening](https://img.shields.io/static/v1?label=Status&message=hardening&color=yellow)](https://github.com/open-feature/spec/tree/main/specification#hardening)

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -186,7 +186,7 @@ class MyProvider implements Provider {
   //...
 
   // the global context and the bound domain are passed to the initialization function
-  void initialize(EvaluationContext initialContext, String domain) {
+  void initialize(EvaluationContext initialContext, @Nullable String domain) {
     this.domain = domain;
     /*
       A hypothetical initialization function: make an initial call doing some bulk initial evaluation, start a worker to do periodic updates

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -214,12 +214,11 @@ see: [error codes](../types.md#error-code)
 When a provider is bound to a [domain](../glossary.md#domain), it may need to scope behavior to that domain, such as partitioning a persistent cache or labeling telemetry, so that multiple providers sharing the same storage do not collide.
 Supplying the `domain` at initialization mirrors how the global `evaluation context` is supplied (see [Requirement 2.4.1](#requirement-241)).
 
-```java
+```typescript
 class MyProvider implements Provider {
   // the global context and the bound domain are passed to the initialization function
-  void initialize(EvaluationContext initialContext, String domain) {
-    this.cacheKeyPrefix = domain; // scope persisted state to this domain
-    this.flagCache = this.restClient.bulkEvaluate(initialContext);
+  async initialize(initialContext: EvaluationContext, domain?: string): Promise<void> {
+    this.domain = domain;
   }
 }
 ```

--- a/specification/sections/02-providers.md
+++ b/specification/sections/02-providers.md
@@ -170,23 +170,26 @@ class MyProvider implements Provider {
 
 #### Requirement 2.4.1
 
-> The `provider` **MAY** define an initialization function which accepts the global `evaluation context` as an argument and performs initialization logic relevant to the provider.
+> The `provider` **MAY** define an initialization function which accepts the global `evaluation context` and the bound `domain` (if any) as arguments and performs initialization logic relevant to the provider.
 
 Many feature flag frameworks or SDKs require some initialization before they can be used.
 They might require the completion of an HTTP request, establishing persistent connections, or starting timers or worker threads.
 The initialization function is an ideal place for such logic.
 
-```java
+The `domain` the provider is registered under is also supplied, allowing the provider to scope domain-specific behavior, such as partitioning a persistent cache, so that multiple providers sharing the same storage do not collide.
+A `provider` instance is initialized only once, even when bound to multiple `domains`; in that case the `domain` supplied is the one under which it was first registered.
+The default provider, which is not bound to a domain, is initialized without one.
+
+```typescript
 // MyProvider implementation of the initialize function defined in Provider
 class MyProvider implements Provider {
   //...
 
-  // the global context is passed to the initialization function
-  void initialize(EvaluationContext initialContext) {
-    /*
-      A hypothetical initialization function: make an initial call doing some bulk initial evaluation, start a worker to do periodic updates
-    */
-    this.flagCache = this.restClient.bulkEvaluate(initialContext);
+  // the global context and the bound domain are passed to the initialization function
+  async initialize(initialContext: EvaluationContext, domain?: string): Promise<void> {
+    this.domain = domain;
+    // A hypothetical initialization function: make an initial call doing some bulk initial evaluation, start a worker to do periodic updates
+    this.flagCache = await this.restClient.bulkEvaluate(initialContext);
     this.startPolling();
   }
 
@@ -206,25 +209,6 @@ If a provider is unable to start up correctly, it should indicate abnormal execu
 If the error is irrecoverable (perhaps due to bad credentials or invalid configuration) the `PROVIDER_FATAL` error code should be used.
 
 see: [error codes](../types.md#error-code)
-
-#### Requirement 2.4.3
-
-> The `provider` **MAY** define an initialization function which additionally accepts the `domain` it is registered under, if any.
-
-When a provider is bound to a [domain](../glossary.md#domain), it may need to scope behavior to that domain, such as partitioning a persistent cache or labeling telemetry, so that multiple providers sharing the same storage do not collide.
-Supplying the `domain` at initialization mirrors how the global `evaluation context` is supplied (see [Requirement 2.4.1](#requirement-241)).
-
-```typescript
-class MyProvider implements Provider {
-  // the global context and the bound domain are passed to the initialization function
-  async initialize(initialContext: EvaluationContext, domain?: string): Promise<void> {
-    this.domain = domain;
-  }
-}
-```
-
-A `provider` instance is initialized only once, even when bound to multiple `domains`; in that case the `domain` supplied is the one under which it was first registered.
-The default provider, which is not bound to a domain, is initialized without one.
 
 ### 2.5. Shutdown
 


### PR DESCRIPTION
Amends provider initialization so the `domain` a provider is bound to is supplied to its `initialize` function, letting providers scope domain-specific behavior (such as partitioning a persistent cache) to that domain.

## Motivation

Provider-level persistent caches (e.g. the OFREP web provider's local persistence) currently have no way to know which `domain` they're bound to, so two providers on the same storage partition can collide on cache entries even though OpenFeature's domain model is supposed to keep them isolated. See [slack thread](https://cloud-native.slack.com/archives/C06E4DE6S07/p1780526010480869), [open-feature/js-sdk-contrib#1566](https://github.com/open-feature/js-sdk-contrib/pull/1566), and [ADR 0009](https://github.com/open-feature/protocol/blob/main/service/adrs/0009-local-storage-for-static-context-providers.md).

A follow-up OFREP ADR will add the domain to the cache key.

## Changes

Two parts, both kept language-agnostic so implementations can use overloads, optional arguments, etc.:

**Supply the bound domain to init** (folded into the existing init requirements, per earlier review feedback):

- `2.4.1` (provider): the `initialize` function accepts the global `evaluation context` **and the bound `domain`** (if any).
- `1.1.2.2` (API): the `provider mutator` **MUST** supply the bound `domain` (if any) when invoking `initialize`.

**Let a provider declare it's domain-scoped, enforced by the API** (new requirements):

- `2.4.3` (provider): a `provider` **MAY** declare itself `domain-scoped` when it holds per-`domain` state such as a persistent cache.
- `1.1.8` (condition) / `1.1.8.1` (API): when a provider is `domain-scoped`, the `provider mutator` **MUST NOT** bind it to more than one `domain`, and rejects any attempt to do so.

## Resolved

The earlier open question (a provider bound to multiple `domains` is initialized once and receives only its first binding's `domain`) is now addressed for stateful providers: declaring `domain-scoped` restricts the instance to a single `domain`, so the `domain` it keys on is unambiguous. Stateless providers are unaffected and can still back multiple `domains`.