### PR TITLE
fix: update dead CNCF Slack invite link

### DIFF
--- a/specification/appendix-c/index.md
+++ b/specification/appendix-c/index.md
@@ -16,7 +16,7 @@ There is a dedicated [OpenFeature working group](https://github.com/open-feature
 - Telemetry enrichment of the evaluations
 - Reference implementations of the protocol
 
-If you are interested in this initiative, you can join the [`#openfeature-remote-evaluation-protocol`](https://cloud-native.slack.com/archives/C066A48LK35) Slack channel on the [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) workspace.
+If you are interested in this initiative, you can join the [`#openfeature-remote-evaluation-protocol`](https://cloud-native.slack.com/archives/C066A48LK35) Slack channel on the [CNCF Slack](https://slack.cncf.io/) workspace.
 
 ## API Specification
 


### PR DESCRIPTION
## Summary

- The CNCF Slack invite link in appendix-c (`https://communityinviter.com/apps/cloud-native/cncf`) now returns a 404, which fails the `json-lint` link check on `main`.
- Replaced it with the official CNCF Slack signup URL `https://slack.cncf.io/`.