### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/.markdown-link-check-config.json
+++ b/.markdown-link-check-config.json
@@ -1,4 +1,5 @@
 {
+  "retryOn429": true,
   "ignorePatterns": [
     {
       "pattern": ".*split.io.*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2530,10 +2530,14 @@
       }
     },
     "node_modules/toml": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
-      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-5.0.0.tgz",
+      "integrity": "sha512-bsqEd+g7fzlrw7LEynQ6W6aOK/lTOlepz5x1sJyIV9fTZVJS2Q76nuju6FK+gZhW5bUpvB7mCEqdR0u4WziMFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/tslib": {
       "version": "2.4.0",
@@ -3108,7 +3112,7 @@
         "coffee-script": "^1.12.4",
         "extend-shallow": "^2.0.1",
         "js-yaml": "^3.8.1",
-        "toml": "^2.3.2"
+        "toml": ">=4.1.2"
       }
     },
     "gulp-header": {
@@ -4289,9 +4293,9 @@
       }
     },
     "toml": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
-      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-5.0.0.tgz",
+      "integrity": "sha512-bsqEd+g7fzlrw7LEynQ6W6aOK/lTOlepz5x1sJyIV9fTZVJS2Q76nuju6FK+gZhW5bUpvB7mCEqdR0u4WziMFw==",
       "dev": true
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "markdown-toc": "^1.2.0",
     "markdownlint-cli": "^0.49.1",
     "prettier": "^3.0.0"
+  },
+  "overrides": {
+    "toml": ">=4.1.2"
   }
 }


### PR DESCRIPTION
## Summary

- Overrode transitive `toml` dependency to `>=4.1.2` to resolve a high severity prototype pollution vulnerability (alert #42)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #42 | `toml` | **high** | Overrode to `>=4.1.2` (resolves to 5.0.0) via npm `overrides`, since the vulnerable version is pulled in transitively through `markdown-toc` -> `gray-matter@2.1.1`, and `markdown-toc` (unmaintained, latest is 1.2.0) pins `gray-matter" to `^2.1.0`, which cannot resolve to a gray-matter version without the vulnerable toml dependency. Verified `make markdown-toc` produces identical output with the overridden toml version.