### PR TITLE
fix: replace dead CNCF Slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://github.com/open-feature/.github/blob/main/CONTRIBUTING.md">
     <img alt="Contributing" src="https://img.shields.io/static/v1?label=Contributing&message=guide&color=blue" />
   </a>
-  <a href="https://cloud-native.slack.com/archives/C0344AANLA1">
+  <a href="https://slack.cncf.io/">
     <img alt="Slack" src="https://img.shields.io/badge/slack-%40cncf%2Fopenfeature-brightgreen?style=flat&logo=slack"/>
   </a>
   <a href="https://bestpractices.coreinfrastructure.org/projects/6601">

--- a/specification/appendix-c/index.md
+++ b/specification/appendix-c/index.md
@@ -16,7 +16,7 @@ There is a dedicated [OpenFeature working group](https://github.com/open-feature
 - Telemetry enrichment of the evaluations
 - Reference implementations of the protocol
 
-If you are interested in this initiative, you can join the [`#openfeature-remote-evaluation-protocol`](https://cloud-native.slack.com/archives/C066A48LK35) Slack channel on the [CNCF Slack](https://slack.cncf.io/) workspace.
+If you are interested in this initiative, you can join the `#openfeature-remote-evaluation-protocol` Slack channel on the [CNCF Slack](https://slack.cncf.io/) workspace.
 
 ## API Specification
 


### PR DESCRIPTION
## This PR

- points the Slack badge in `README.md` at `https://slack.cncf.io/`
- drops the dead channel link in `specification/appendix-c/index.md`, keeping the channel name and the CNCF Slack link already in that sentence

### Notes

`cloud-native.slack.com` returns 403 to any unauthenticated client now, not just the two archive URLs — `https://cloud-native.slack.com/` itself does as well. There is no channel-specific link to swap in; anything under that host fails the check.

`https://slack.cncf.io/` is where #419 moved appendix-c's other link in August, and it is what openfeature.dev's community page links for joining, so I have used it rather than adding a third destination.

The same archive link is in the README of go-sdk, js-sdk, java-sdk, python-sdk and dotnet-sdk, and in the openfeature.dev footer. Happy to send those separately if you want them.

### How to test

`./node_modules/.bin/markdown-link-check -c .markdown-link-check-config.json README.md specification/*.md specification/**/*.md` is clean across all 15 files. Run it with `sh`, not zsh — zsh expands `**` recursively and checks a different set.